### PR TITLE
Fix _DataStore being stored as updating DataModel

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -258,12 +258,13 @@ class Connection extends BaseConnection {
      */
     Set (KeyOrPath, Value) {
         if (!this._Ready) return null;
+        if (typeof Value === "object") delete Value._DataStore;
         const [Key, Path] = this._ResolvePath(KeyOrPath.toString());
 
         if (typeof Path !== "undefined") Value = this._CastPath(this.Fetch(Key), Path, {Item: Value});
         else if (typeof Value !== "object") return null;
 
-        if (this.Cache.has(Key)) this.Cache.set(Key, Value);
+        if (this.Cache.has(Key)) this.Cache.set(Key, Value instanceof Array ? [...Value] : {...Value});
         this.API.prepare(`INSERT OR REPLACE INTO '${this.Table}' ('Key', 'Val') VALUES (?, ?);`)
         .run(Key, JSON.stringify(Value));
 
@@ -284,8 +285,11 @@ class Connection extends BaseConnection {
         JSON.parse(this.API.prepare(`SELECT * FROM '${this.Table}' WHERE Key = ?;`).get(Key)["Val"]);
 
         if (typeof Fetched === "undefined") return undefined;
-        if (!this.Cache.has(Key) && Cache) this.Cache.set(Key, Fetched instanceof Array ? [...Fetched] : {...Fetched});
+        if (!this.Cache.has(Key) && Cache) this.Cache.set(Key, Fetched);
+
+        Fetched = Fetched instanceof Array ? [...Fetched] : {...Fetched};
         if (typeof Path !== "undefined") Fetched = this._CastPath(Fetched, Path);
+        if (typeof Fetched === "object") delete Fetched._DataStore;
 
         return Fetched;
     }


### PR DESCRIPTION
Fixed it by deep-cloning the Object or Array, so the DataStore making changes by adding `_DataStore` won't be stored into the database

Secondly, added a statement that removes the tag when it fetched from cache. also deep cloning it - Otherwise it would update in the DataStore

Resolves #2 