### PR TITLE
Fixed error throwing when trying to fetch a nonexistent key

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -281,10 +281,13 @@ class Connection extends BaseConnection {
         if (!this._Ready) return null;
         const [Key, Path] = this._ResolvePath(KeyOrPath.toString());
 
-        let Fetched = this.Cache.has(Key) ? this.Cache.resolve(Key) :
-        JSON.parse(this.API.prepare(`SELECT * FROM '${this.Table}' WHERE Key = ?;`).get(Key)["Val"]);
+        let Fetched = this.Cache.resolve(Key) || (() => {
+            const Req = this.API.prepare(`SELECT * FROM '${this.Table}' WHERE Key = ?;`).get(Key);
+            if (typeof Req !== "undefined") return JSON.parse(Req.Val);
+            else return Req;
+        })();
 
-        if (typeof Fetched === "undefined") return undefined;
+        if (Fetched === null || Fetched === undefined) return Fetched;
         if (!this.Cache.has(Key) && Cache) this.Cache.set(Key, Fetched);
 
         Fetched = Fetched instanceof Array ? [...Fetched] : {...Fetched};

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -261,7 +261,7 @@ class Connection extends BaseConnection {
         if (typeof Value === "object") delete Value._DataStore;
         const [Key, Path] = this._ResolvePath(KeyOrPath.toString());
 
-        if (typeof Path !== "undefined") Value = this._CastPath(this.Fetch(Key), Path, {Item: Value});
+        if (typeof Path !== "undefined") Value = this._CastPath(this.Fetch(Key) || {}, Path, {Item: Value});
         else if (typeof Value !== "object") return null;
 
         if (this.Cache.has(Key)) this.Cache.set(Key, Value instanceof Array ? [...Value] : {...Value});


### PR DESCRIPTION
Error would be thrown if you'd fetch a row which didn't exist. It now returns either `undefined` or `null`, based on if it were to be undefined, or if the row contained a nil value

Also fixed path casting when you'd create an object but the row didn't exist

Resolves #3 