### PR TITLE
Added cache sweeping and fetchAll

### DIFF
--- a/Documentation/Connection.md
+++ b/Documentation/Connection.md
@@ -30,35 +30,35 @@ const MyDB = new QDB.Connection("lib/Databases/Users.qdb");
 ## [.ValOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L36)
 > Validated options for this Connection. [**Read Only**]
 >
-> Type **{Object}**
+> Type **{RawOptions}**
 
-## [.Table](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L52)
+## [.Table](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L53)
 > Table name for this Connection. [**Read Only**]
 >
 > Type **{String}**
 
-## [.Size](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L104)
+## [.Size](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L120)
 > Fetches all the rows of this database.
 >
 > Type **{Number}**
 
-## [.CacheSize](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L114)
+## [.CacheSize](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L130)
 > Retrieves all the in-memory cached rows of this Connection. Extension of what would be `<Connection>.Cache.size`, but checks for the ready state.
 >
 > Type **{Number}**
 
 # Methods
-## [.Disconnect()](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L125)
+## [.Disconnect()](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L141)
 > Disconnects from the database, clears in-memory rows.
 >
 > Returns **{PartialConnection}** 
 
-## [.AsObject()](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L140)
+## [.AsObject()](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L159)
 > Converts this database to an Object. To use dotaccess, use `Fetch` instead.
 >
 > Returns **{Object}** An Object instance with the key/value pairs.
 
-## [.ToInstance(Instance, Pathlike?, Args?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L150)
+## [.ToInstance(Instance, Pathlike?, Args?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L169)
 > Converts this database, or a part of it using dotaccess, to any Map-form instance.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -68,7 +68,7 @@ const MyDB = new QDB.Connection("lib/Databases/Users.qdb");
 >
 > Returns **{Any}** The instance with the target as entries.
 
-## [.ToDataStore(Pathlike?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L169)
+## [.ToDataStore(Pathlike?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L188)
 > Converts this database, or a part of it using dotaccess, to a DataStore instance.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -76,7 +76,7 @@ const MyDB = new QDB.Connection("lib/Databases/Users.qdb");
 >
 > Returns **{DataStore}** A DataStore instance with the key/model pairs.
 
-## [.ToIntegratedManager(Pathlike?, Holds?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L178)
+## [.ToIntegratedManager(Pathlike?, Holds?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L197)
 > Converts this database, or a part of it using dotaccess, to a Manager instance.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -85,7 +85,7 @@ const MyDB = new QDB.Connection("lib/Databases/Users.qdb");
 >
 > Returns **{Manager}** A Manager instance with the key/model pairs.
 
-## [.Set(KeyOrPath, Value)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L261)
+## [.Set(KeyOrPath, Value)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L293)
 > Manages the elements of the database.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -94,16 +94,16 @@ const MyDB = new QDB.Connection("lib/Databases/Users.qdb");
 >
 > Returns **{Connection}** Returns the updated database.
 
-## [.Fetch(KeyOrPath, Cache?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L282)
+## [.Fetch(KeyOrPath, Cache?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L314)
 > Manages the retrieval of the database.
 > | Key | Type | Description |
 > | --- | --- | --- |
 > | KeyOrPath | String | Specifies which row to fetch or get from cache. Use dotaccess notation to retrieve in-depth values. |
 > | Cache? | Boolean | Whether to, when not already, cache this entry in results that the next retrieval would be much faster. |
 >
-> Returns **{Object|Array|Any}** Value of the row, or the property when using dotaccess.
+> Returns **{Object|Array|DataModel|Any}** Value of the row, or the property when using dotaccess.
 
-## [.Evict(Keys?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L308)
+## [.Evict(Keys?)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L340)
 > Removes elements from this Connection's cache.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -111,7 +111,7 @@ const MyDB = new QDB.Connection("lib/Databases/Users.qdb");
 >
 > Returns **{Connection}** Returns the updated database.
 
-## [.Erase(Keys)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L320)
+## [.Erase(Keys)](https://github.com/QSmally/QDB/blob/v4/lib/Connection.js#L352)
 > Removes elements from this database.
 > | Key | Type | Description |
 > | --- | --- | --- |

--- a/Documentation/Types.md
+++ b/Documentation/Types.md
@@ -13,15 +13,17 @@
 > Raw options for setting up a Connection.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | FetchAll? | Boolean | Whether to fetch all entries on startup. |
-> | SweepInterval? | Number | Integer to indicate the interval of cache sweeping. |
+> | Table? | String | The name of the table to use for this Connection's database. |
+> | Cache? | Boolean | Boolean to indicate whether to cache newly fetched entries. |
+> | SweepTime? | Number | Integer to indicate the interval of cache sweeping. |
+> | SweepLife? | Number | Integer to determine how old a cache entry has to be for it to be swept. |
+> | FetchAll? | Boolean | Whether to fetch all entries on startup of this Connection. |
 > | Backups? | String, Boolean | String for the path of the backup directory, otherwise 'false'. |
-> | Cache? | Boolean | Boolean to indicate whether to cache newly fetched entries. (This WILL increase memory usage.) |
 > | WAL? | Boolean | Boolean to indicate whether to use Write Ahead Logging as journal mode. |
 >
 > Type **{Object}**
 
-## [.Pathlike](https://github.com/QSmally/QDB/blob/v4/lib/Types.js#L12)
+## [.Pathlike](https://github.com/QSmally/QDB/blob/v4/lib/Types.js#L14)
 > A path to some sort of file or directory.
 >
 > Type **{String}**

--- a/Test/Benchmark.js
+++ b/Test/Benchmark.js
@@ -3,7 +3,7 @@ const QDB = require("../QDB");
 
 const Guilds = new QDB.Connection("Test/Guilds.qdb", {
     // Change this to true/false for (no) caching
-    Cache: false
+    // Cache: false
 });
 
 // START READ TIME
@@ -23,6 +23,8 @@ for (let i = 0; i < 1000 * 1000; i++) {
 console.log(`cache size: ${Guilds.CacheSize}`);
 console.timeEnd("time-for-million-reads");
 console.log(`memory usage: ${process.memoryUsage().heapUsed / 1024 / 1024} MB`);
+
+Guilds.Disconnect();
 
 
 

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -36,16 +36,17 @@ class Connection extends BaseConnection {
             /**
              * Validated options for this Connection.
              * @name Connection#ValOptions
-             * @type {Object}
+             * @type {RawOptions}
              * @readonly
              */
             Object.defineProperty(this, "ValOptions", {
                 value: {
-                    FetchAll:      typeof RawOptions.FetchAll === "undefined"      ? false : (RawOptions.Backups ? true : false),
-                    SweepInterval: typeof RawOptions.SweepInterval === "undefined" ? 86400000 : parseInt(RawOptions.SweepInterval),
-                    Backups:       typeof RawOptions.Backups === "undefined"       ? false : RawOptions.Backups.toString(),
-                    Cache:         typeof RawOptions.Cache === "undefined"         ? true : (RawOptions.Cache ? true : false),
-                    WAL:           typeof RawOptions.WAL === "undefined"           ? true : (RawOptions.WAL ? true : false)
+                    Cache:     typeof RawOptions.Cache === "undefined"     ? true : (RawOptions.Cache ? true : false),
+                    SweepTime: typeof RawOptions.SweepTime === "undefined" ? 86400000 : parseInt(RawOptions.SweepTime),
+                    SweepLife: typeof RawOptions.SweepLife === "undefined" ? 5400000 : parseInt(RawOptions.SweepLife),
+                    FetchAll:  typeof RawOptions.FetchAll === "undefined"  ? false : (RawOptions.FetchAll ? true : false),
+                    Backups:   typeof RawOptions.Backups === "undefined"   ? false : RawOptions.Backups.toString(),
+                    WAL:       typeof RawOptions.WAL === "undefined"       ? true : (RawOptions.WAL ? true : false)
                 }
             });
 
@@ -96,7 +97,22 @@ class Connection extends BaseConnection {
         }
 
 
-        // TODO: add fetchAll support, cache sweep and backups
+        if (this.ValOptions.FetchAll) {
+            this.API.prepare(`SELECT * FROM '${this.Table}';`)
+            .forEach((Val, Key) => this.Cache.set(Key, Val));
+        }
+
+        if (this.ValOptions.SweepTime) {
+            Object.defineProperty(this, "_Sweep", {
+                value: setInterval(() => {
+                    this.Cache.sweep(e => Date.now() - e._Timestamp >= this.ValOptions.SweepLife);
+                }, this.ValOptions.SweepTime)
+            });
+        }
+
+        if (this.ValOptions.Backups) {
+            
+        }
 
     }
 
@@ -128,9 +144,12 @@ class Connection extends BaseConnection {
      */
     Disconnect () {
         const PartialConnection = require("./PartialConnection");
-        this.State = "DISCONNECTED";
+
         this.API.close();
         this.Cache.clear();
+
+        clearInterval(this._Sweep);
+        this.State = "DISCONNECTED";
         return new PartialConnection();
     }
 
@@ -197,6 +216,19 @@ class Connection extends BaseConnection {
         if (this.State !== "CONNECTED") return false;
         if (!this.API.open) return false;
         return true;
+    }
+
+    /**
+     * Sets or patches something in this Connection's internal cache.
+     * @param {String|Number} Key As address to memory map this value.
+     * @param {Object|Array} Val The value to internally cache.
+     * @returns {DataStore} Returns the updated cache.
+     * @private
+     */
+    _PatchCache (Key, Val) {
+        Val._Timestamp = Date.now();
+        this.Cache.set(Key, Val);
+        return this.Cache;
     }
 
     /**
@@ -283,7 +315,7 @@ class Connection extends BaseConnection {
      * Manages the retrieval of the database.
      * @param {String} KeyOrPath Specifies which row to fetch or get from cache. Use dotaccess notation to retrieve in-depth values.
      * @param {Boolean} [Cache] Whether to, when not already, cache this entry in results that the next retrieval would be much faster.
-     * @returns {Object|Array|*} Value of the row, or the property when using dotaccess.
+     * @returns {Object|Array|DataModel|*} Value of the row, or the property when using dotaccess.
      */
     Fetch (KeyOrPath, Cache = this.ValOptions.Cache) {
         if (!this._Ready) return null;
@@ -296,11 +328,11 @@ class Connection extends BaseConnection {
         })();
 
         if (Fetched === null || Fetched === undefined) return Fetched;
-        if (!this.Cache.has(Key) && Cache) this.Cache.set(Key, Fetched);
+        if (!this.Cache.has(Key) && Cache) this._PatchCache(Key, Fetched);
 
         Fetched = Fetched instanceof Array ? [...Fetched] : {...Fetched};
         if (typeof Path !== "undefined") Fetched = this._CastPath(Fetched, Path);
-        if (typeof Fetched === "object") delete Fetched._DataStore;
+        if (typeof Fetched === "object") delete Fetched._Timestamp;
 
         return Fetched;
     }

--- a/lib/Types.js
+++ b/lib/Types.js
@@ -2,10 +2,12 @@
 /**
  * Raw options for setting up a Connection.
  * @typedef {Object} RawOptions
- * @param {Boolean} [FetchAll] Whether to fetch all entries on startup.
- * @param {Number} [SweepInterval] Integer to indicate the interval of cache sweeping.
+ * @param {String} [Table] The name of the table to use for this Connection's database.
+ * @param {Boolean} [Cache] Boolean to indicate whether to cache newly fetched entries.
+ * @param {Number} [SweepTime] Integer to indicate the interval of cache sweeping.
+ * @param {Number} [SweepLife] Integer to determine how old a cache entry has to be for it to be swept.
+ * @param {Boolean} [FetchAll] Whether to fetch all entries on startup of this Connection.
  * @param {String|Boolean} [Backups] String for the path of the backup directory, otherwise 'false'.
- * @param {Boolean} [Cache] Boolean to indicate whether to cache newly fetched entries. (This WILL increase memory usage.)
  * @param {Boolean} [WAL] Boolean to indicate whether to use Write Ahead Logging as journal mode.
  */
 


### PR DESCRIPTION
Implemented a `_PatchCache` method which adds a `_Timestamp` property to the entry of the cache.

After each 'SweepTime' interval, it checks if the '_Timestamp' is greater than 'SweepLife'. If so, it removes that entry.

I also added `FetchAll` support, caching all entries upon startup. This is disabled as default.