### PR TITLE
Temporary CacheMaxSize optimisation

### DIFF
--- a/Test/Benchmark.js
+++ b/Test/Benchmark.js
@@ -41,9 +41,7 @@ async function Thread () {
 // Million queries benchmark
 function Fetch () {
     const Guilds = new QDB.Connection("Test/Guilds.qdb", {
-        Cache: true,
-        CacheMaxSize: false,
-        FetchAll: true
+        Cache: true
     });
 
     console.log("benchmark: fetch 1 million random queries");
@@ -55,18 +53,11 @@ function Fetch () {
         const Id = Indexes[Math.round(Math.random() * Indexes.length)];
         if (!Id) continue;
         Guilds.Fetch(Id);
-        
-        if (i % 10000 == 0) {
-            console.log({i, CacheSize: Guilds.CacheSize, op: Guilds.local});
-            Guilds.local = {hits: 0, misses: 0};
-        }
     }
 
     console.log(`cache size: ${Guilds.CacheSize}`);
     console.timeEnd("time-for-million-reads");
     console.log(`memory usage: ${process.memoryUsage().heapUsed / 1024 / 1024} MB`);
-
-    console.log(Guilds.global);
 
     if (Disconnect) Guilds.Disconnect();
 }

--- a/Test/Benchmark.js
+++ b/Test/Benchmark.js
@@ -42,7 +42,8 @@ async function Thread () {
 function Fetch () {
     const Guilds = new QDB.Connection("Test/Guilds.qdb", {
         Cache: true,
-        CacheMaxSize: 12000
+        CacheMaxSize: false,
+        FetchAll: true
     });
 
     console.log("benchmark: fetch 1 million random queries");

--- a/Test/Benchmark.js
+++ b/Test/Benchmark.js
@@ -41,7 +41,8 @@ async function Thread () {
 // Million queries benchmark
 function Fetch () {
     const Guilds = new QDB.Connection("Test/Guilds.qdb", {
-        Cache: true
+        Cache: true,
+        CacheMaxSize: 20000
     });
 
     console.log("benchmark: fetch 1 million random queries");
@@ -53,6 +54,7 @@ function Fetch () {
         const Id = Indexes[Math.round(Math.random() * Indexes.length)];
         if (!Id) continue;
         Guilds.Fetch(Id);
+        // if (i % 1000 == 0) console.log({i, CacheSize: Guilds.CacheSize});
     }
 
     console.log(`cache size: ${Guilds.CacheSize}`);

--- a/Test/Benchmark.js
+++ b/Test/Benchmark.js
@@ -42,7 +42,7 @@ async function Thread () {
 function Fetch () {
     const Guilds = new QDB.Connection("Test/Guilds.qdb", {
         Cache: true,
-        CacheMaxSize: 20000
+        CacheMaxSize: 12000
     });
 
     console.log("benchmark: fetch 1 million random queries");
@@ -54,12 +54,18 @@ function Fetch () {
         const Id = Indexes[Math.round(Math.random() * Indexes.length)];
         if (!Id) continue;
         Guilds.Fetch(Id);
-        // if (i % 1000 == 0) console.log({i, CacheSize: Guilds.CacheSize});
+        
+        if (i % 10000 == 0) {
+            console.log({i, CacheSize: Guilds.CacheSize, op: Guilds.local});
+            Guilds.local = {hits: 0, misses: 0};
+        }
     }
 
     console.log(`cache size: ${Guilds.CacheSize}`);
     console.timeEnd("time-for-million-reads");
     console.log(`memory usage: ${process.memoryUsage().heapUsed / 1024 / 1024} MB`);
+
+    console.log(Guilds.global);
 
     if (Disconnect) Guilds.Disconnect();
 }

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -228,13 +228,23 @@ class Connection extends PartialConnection {
             this.Cache.size >= this.ValOptions.CacheMaxSize &&
             !this.Cache.has(Key)) {
 
-            const [Key] = this.Cache.reduce((Accumulator, Entry, Key) => {
-                if (!Accumulator[1] || Entry._Timestamp < Accumulator[1])
-                return [Key, Entry._Timestamp];
-                else return Accumulator;
-            }, []);
+            // Evict half based on TTL
+            this.Cache.sort((Accumulator, Entry) => Accumulator._Timestamp - Entry._Timestamp);
+            this.Evict(this.Cache.first(this.ValOptions.CacheMaxSize / 2));
 
-            this.Cache.delete(Key);
+
+            // Evict one based on TTL
+            // const [Key] = this.Cache.reduce((Accumulator, Entry, Key) => {
+            //     if (!Accumulator[1] || Entry._Timestamp < Accumulator[1])
+            //     return [Key, Entry._Timestamp];
+            //     else return Accumulator;
+            // }, []);
+
+            // this.Cache.delete(Key);
+
+
+            // Evict all
+            // this.Evict();
         }
 
         const Value = Val instanceof Array ? [...Val] : {...Val};

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -24,6 +24,9 @@ class Connection extends PartialConnection {
 
             super();
 
+            this.local = {hits: 0, misses: 0};
+            this.global = {hits: 0, misses: 0};
+
             this.State = "CONNECTED";
 
             /**
@@ -379,6 +382,9 @@ class Connection extends PartialConnection {
             if (typeof Req !== "undefined") return JSON.parse(Req.Val);
             else return Req;
         })();
+
+        this.local[Fetched._DataStore ? "hits" : "misses"]++;
+        this.global[Fetched._DataStore ? "hits" : "misses"]++;
 
         if (Fetched === null || Fetched === undefined) return Fetched;
         if (Cache && !this.Cache.has(Key)) this._Patch(Key, Fetched);

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -230,7 +230,7 @@ class Connection extends PartialConnection {
 
             // Evict half based on TTL
             this.Cache.sort((Accumulator, Entry) => Accumulator._Timestamp - Entry._Timestamp);
-            this.Evict(this.Cache.first(this.ValOptions.CacheMaxSize / 2));
+            this.Evict(...this.Cache.first(this.ValOptions.CacheMaxSize / 2));
 
 
             // Evict one based on TTL

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -24,9 +24,6 @@ class Connection extends PartialConnection {
 
             super();
 
-            this.local = {hits: 0, misses: 0};
-            this.global = {hits: 0, misses: 0};
-
             this.State = "CONNECTED";
 
             /**
@@ -382,9 +379,6 @@ class Connection extends PartialConnection {
             if (typeof Req !== "undefined") return JSON.parse(Req.Val);
             else return Req;
         })();
-
-        this.local[Fetched._DataStore ? "hits" : "misses"]++;
-        this.global[Fetched._DataStore ? "hits" : "misses"]++;
 
         if (Fetched === null || Fetched === undefined) return Fetched;
         if (Cache && !this.Cache.has(Key)) this._Patch(Key, Fetched);

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -226,39 +226,7 @@ class Connection extends PartialConnection {
     _Patch (Key, Val) {
         if (this.ValOptions.CacheMaxSize &&
             this.Cache.size >= this.ValOptions.CacheMaxSize &&
-            !this.Cache.has(Key)) {
-
-            // Evict half based on TTL
-            // Third fastest
-            // this.Cache.sort((Accumulator, Entry) => Accumulator._Timestamp - Entry._Timestamp);
-            // this.Evict(...this.Cache.first(this.ValOptions.CacheMaxSize / 2));
-
-
-            // Evict one based on TTL
-            // Slowest
-            // const [Key] = this.Cache.reduce((Accumulator, Entry, Key) => {
-            //     if (!Accumulator[1] || Entry._Timestamp < Accumulator[1])
-            //     return [Key, Entry._Timestamp];
-            //     else return Accumulator;
-            // }, []);
-
-            // this.Cache.delete(Key);
-
-
-            // Evict all
-            // Second fastest
-            // this.Evict();
-
-
-            // Don't add anything
-            // Fastest
-            return this.Cache;
-
-
-            // Delete last TTL
-            // Slower if done with 20k
-            // this.Cache.delete(this.Cache.last()._DataStore);
-        }
+            !this.Cache.has(Key)) return this.Cache;
 
         const Value = Val instanceof Array ? [...Val] : {...Val};
         Value._Timestamp = Date.now();

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -229,11 +229,13 @@ class Connection extends PartialConnection {
             !this.Cache.has(Key)) {
 
             // Evict half based on TTL
-            this.Cache.sort((Accumulator, Entry) => Accumulator._Timestamp - Entry._Timestamp);
-            this.Evict(...this.Cache.first(this.ValOptions.CacheMaxSize / 2));
+            // Third fastest
+            // this.Cache.sort((Accumulator, Entry) => Accumulator._Timestamp - Entry._Timestamp);
+            // this.Evict(...this.Cache.first(this.ValOptions.CacheMaxSize / 2));
 
 
             // Evict one based on TTL
+            // Slowest
             // const [Key] = this.Cache.reduce((Accumulator, Entry, Key) => {
             //     if (!Accumulator[1] || Entry._Timestamp < Accumulator[1])
             //     return [Key, Entry._Timestamp];
@@ -244,7 +246,18 @@ class Connection extends PartialConnection {
 
 
             // Evict all
+            // Second fastest
             // this.Evict();
+
+
+            // Don't add anything
+            // Fastest
+            return this.Cache;
+
+
+            // Delete last TTL
+            // Slower if done with 20k
+            // this.Cache.delete(this.Cache.last()._DataStore);
         }
 
         const Value = Val instanceof Array ? [...Val] : {...Val};


### PR DESCRIPTION
As of writing this PR, the only eviction strategy I'm implementing will be to block all new entries for the cache until cache space has cleared up, either manually or through the sweep interval.

Sometime in the future, I'm not sure when, I'll probably add different eviction methods that'll be selected in the Connection options - because some methods are faster than others, that differs per the size and usage of the database. I might also add an automatic strategy based on size.

Fixes #17 