### PR TITLE
Fix FetchAll parsing

### DIFF
--- a/lib/Executors/Client/Fetch.js
+++ b/lib/Executors/Client/Fetch.js
@@ -6,6 +6,6 @@
  */
 module.exports = Connection => {
     Connection.API.prepare(`SELECT * FROM '${Connection.Table}';`)
-    .all().forEach(Entry => Connection._Patch(Entry.Key, Entry.Val));
+    .all().forEach(Entry => Connection._Patch(Entry.Key, JSON.parse(Entry.Val)));
     return Connection.CacheSize;
 }


### PR DESCRIPTION
I previously assumed that the private patch method would parse the entry of the database. This led to the cache having strings as values, instead of decoded data models, and would lead to other errors.