### PR TITLE
Implement Selection#Join() and better clone

### DIFF
--- a/Documentation/Output.json
+++ b/Documentation/Output.json
@@ -488,17 +488,27 @@
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 16,
+            "Line": 17,
             "Description": "Cached dataset instances of this Selection.",
             "Type": "{Collection}",
             "Reference": "https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md"
+        },
+        {
+            "Value": "Holds",
+            "Flags": [
+                "Variable",
+                "ReadOnly"
+            ],
+            "Line": 32,
+            "Description": "Reference to the table this Selection holds.",
+            "Type": "{String}"
         },
         {
             "Value": "Keys",
             "Flags": [
                 "Variable"
             ],
-            "Line": 34,
+            "Line": 46,
             "Description": "Serialises this Selection's keys into an array.",
             "Action": "Getter",
             "Refer": "Keys",
@@ -509,7 +519,7 @@
             "Flags": [
                 "Variable"
             ],
-            "Line": 43,
+            "Line": 55,
             "Description": "Serialises this Selection's values into an array.",
             "Action": "Getter",
             "Refer": "Values",
@@ -520,7 +530,7 @@
             "Flags": [
                 "Variable"
             ],
-            "Line": 52,
+            "Line": 64,
             "Description": "Serialises this Selection into an object.",
             "Action": "Getter",
             "Refer": "AsObject",
@@ -529,7 +539,7 @@
         {
             "Value": "Sort",
             "Flags": [],
-            "Line": 64,
+            "Line": 76,
             "Description": "Sorts this Selection's values. Identical to the `SORT BY` SQL statement.",
             "Params": [
                 "{Function} Fn Function that determines the sort order."
@@ -539,7 +549,7 @@
         {
             "Value": "Filter",
             "Flags": [],
-            "Line": 76,
+            "Line": 88,
             "Description": "Filters values that satisfy the provided function. Identical to the `FILTER BY` SQL statement.",
             "Params": [
                 "{Function} Fn Function that determines which entries to keep."
@@ -549,7 +559,7 @@
         {
             "Value": "Limit",
             "Flags": [],
-            "Line": 92,
+            "Line": 104,
             "Description": "Slices off values from this Selection. Identical to the `LIMIT` SQL statement.",
             "Params": [
                 "{Number} Begin Integer to indicate the beginning to slice.",
@@ -560,7 +570,7 @@
         {
             "Value": "Group",
             "Flags": [],
-            "Line": 115,
+            "Line": 127,
             "Description": "Groups this Selection based on an identifier. Identical to the `GROUP BY` SQL statement.",
             "Params": [
                 "{Pathlike} Key Indicates by which element to group this Selection."
@@ -568,9 +578,21 @@
             "Returns": "{Selection}"
         },
         {
+            "Value": "Join",
+            "Flags": [],
+            "Line": 153,
+            "Description": "Joins another Selection into this instance based on a referrer field. Identical to the `FULL JOIN` SQL statement.",
+            "Params": [
+                "{Selection} Secondary Another Selection instance to join into this one.",
+                "{String} Field Which field to check for a reference to this Selection's rows.",
+                "{Boolean|String} [Property] Boolean false to flatten the entries into this Selection's rows, a string value that implicitly indicates the property to add the merging entries, or a boolean true to use the Selection's table name as property."
+            ],
+            "Returns": "{Selection}"
+        },
+        {
             "Value": "Map",
             "Flags": [],
-            "Line": 144,
+            "Line": 186,
             "Description": "Iterates over this Selection's values and keys, and implements the new values returned from the callback.",
             "Params": [
                 "{Function} Fn Callback function which determines the new values of the Selection."
@@ -580,7 +602,7 @@
         {
             "Value": "Clone",
             "Flags": [],
-            "Line": 159,
+            "Line": 201,
             "Description": "Creates a new memory allocation for the copy of this Selection.",
             "Returns": "{Selection}"
         }

--- a/Documentation/Selection.md
+++ b/Documentation/Selection.md
@@ -19,28 +19,33 @@ A Selection allows you to filter something from the database, and perform method
 
 
 # Values
-## [.Cache](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L16)
+## [.Cache](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L17)
 > Cached dataset instances of this Selection. [**Read Only**]
 >
 > Type **[{Collection}](https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md)**
 
-## [.Keys](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L34)
+## [.Holds](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L32)
+> Reference to the table this Selection holds. [**Read Only**]
+>
+> Type **{String}**
+
+## [.Keys](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L46)
 > Serialises this Selection's keys into an array.
 >
 > Type **{Array}**
 
-## [.Values](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L43)
+## [.Values](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L55)
 > Serialises this Selection's values into an array.
 >
 > Type **{Array}**
 
-## [.AsObject](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L52)
+## [.AsObject](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L64)
 > Serialises this Selection into an object.
 >
 > Type **{Object}**
 
 # Methods
-## [.Sort(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L64)
+## [.Sort(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L76)
 > Sorts this Selection's values. Identical to the `SORT BY` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -48,7 +53,7 @@ A Selection allows you to filter something from the database, and perform method
 >
 > Returns **{Selection}** 
 
-## [.Filter(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L76)
+## [.Filter(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L88)
 > Filters values that satisfy the provided function. Identical to the `FILTER BY` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -56,7 +61,7 @@ A Selection allows you to filter something from the database, and perform method
 >
 > Returns **{Selection}** 
 
-## [.Limit(Begin, End?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L92)
+## [.Limit(Begin, End?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L104)
 > Slices off values from this Selection. Identical to the `LIMIT` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -65,7 +70,7 @@ A Selection allows you to filter something from the database, and perform method
 >
 > Returns **{Selection}** 
 
-## [.Group(Key)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L115)
+## [.Group(Key)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L127)
 > Groups this Selection based on an identifier. Identical to the `GROUP BY` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -73,7 +78,17 @@ A Selection allows you to filter something from the database, and perform method
 >
 > Returns **{Selection}** 
 
-## [.Map(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L144)
+## [.Join(Secondary, Field, Property?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L153)
+> Joins another Selection into this instance based on a referrer field. Identical to the `FULL JOIN` SQL statement.
+> | Key | Type | Description |
+> | --- | --- | --- |
+> | Secondary | Selection | Another Selection instance to join into this one. |
+> | Field | String | Which field to check for a reference to this Selection's rows. |
+> | Property? | Boolean, String | Boolean false to flatten the entries into this Selection's rows, a string value that implicitly indicates the property to add the merging entries, or a boolean true to use the Selection's table name as property. |
+>
+> Returns **{Selection}** 
+
+## [.Map(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L186)
 > Iterates over this Selection's values and keys, and implements the new values returned from the callback.
 > | Key | Type | Description |
 > | --- | --- | --- |
@@ -81,7 +96,7 @@ A Selection allows you to filter something from the database, and perform method
 >
 > Returns **{Selection}** 
 
-## [.Clone()](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L159)
+## [.Clone()](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L201)
 > Creates a new memory allocation for the copy of this Selection.
 >
 > Returns **{Selection}** 

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -496,7 +496,7 @@ class Connection extends PartialConnection {
         })();
 
         const Selection = require("../Utility/Selection");
-        return new Selection(Entries);
+        return new Selection(Entries, this.Table);
     }
 
 

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -203,8 +203,9 @@ class Selection {
      * @returns {Selection}
      */
     Clone () {
-        const SelectionPairs = {...this.Cache.toObject()};
-        return new Selection(SelectionPairs);
+        const {serialize, deserialize} = require("v8");
+        const SelectionPairs = deserialize(serialize(this.AsObject));
+        return new Selection(SelectionPairs, this.Holds);
     }
 
 }

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -11,7 +11,7 @@ class Selection {
      * @param {Object} _Entries Initial selection of entries for this Selection instance.
      * @example const Selection = MyDB.Select(User => User.Age > 20);
      */
-    constructor (_Entries) {
+    constructor (_Entries, _Holds) {
         
         /**
          * Cached dataset instances of this Selection.
@@ -27,6 +27,11 @@ class Selection {
 
         for (const Id in _Entries)
         this.Cache.set(Id, _Entries[Id]);
+
+        Object.defineProperty(this, "Holds", {
+            enumerable: true,
+            value: _Holds
+        });
 
     }
 

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -9,6 +9,7 @@ class Selection {
      * An unchanged piece of the database in memory, to use
      * as baseline of various endpoints to execute functions with.
      * @param {Object} _Entries Initial selection of entries for this Selection instance.
+     * @param {String} _Holds Reference to the table this Selection will hold.
      * @example const Selection = MyDB.Select(User => User.Age > 20);
      */
     constructor (_Entries, _Holds) {
@@ -28,6 +29,12 @@ class Selection {
         for (const Id in _Entries)
         this.Cache.set(Id, _Entries[Id]);
 
+        /**
+         * Reference to the table this Selection holds.
+         * @name Selection#Holds
+         * @type {String}
+         * @readonly
+         */
         Object.defineProperty(this, "Holds", {
             enumerable: true,
             value: _Holds

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -138,6 +138,28 @@ class Selection {
         return this;
     }
 
+    Join (Sel, Field, Attachment) {
+        if (!(Sel instanceof Selection))    return null;
+        if (typeof Field !== "string")      return null;
+        if (typeof Attachment !== "string") return null;
+
+        this.Map(Entry => {
+            Entry[Attachment] = {};
+            return Entry;
+        });
+
+        for (const [Key, Val] of Sel.Cache) {
+            const Id = Val[Field];
+            const Origin = this.Cache.get(Id);
+            if (!Origin) continue;
+
+            Old[Attachment][Key] = Val;
+            this.Cache.set(Id, Origin);
+        }
+
+        return this;
+    }
+
 
     // ---------------------------------------------------------------- Utility methods
 

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -138,6 +138,14 @@ class Selection {
         return this;
     }
 
+    /**
+     * Joins another Selection into this instance based on a referrer field.
+     * Identical to the `FULL JOIN` SQL statement.
+     * @param {Selection} Sel Another Selection instance to join into this one.
+     * @param {String} Field Which field to check for a reference to this Selection's rows.
+     * @param {String} Attachment The name where all the entries should be stored in this Selection.
+     * @returns {Selection}
+     */
     Join (Sel, Field, Attachment) {
         if (!(Sel instanceof Selection))    return null;
         if (typeof Field !== "string")      return null;

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -161,7 +161,7 @@ class Selection {
             const Origin = this.Cache.get(Id);
             if (!Origin) continue;
 
-            Old[Attachment][Key] = Val;
+            Origin[Attachment][Key] = Val;
             this.Cache.set(Id, Origin);
         }
 

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -172,8 +172,8 @@ class Selection {
             let Origin = this.Cache.get(FieldId);
             if (!Origin) continue;
 
-            if (Property) Origin[Key][Id] = Val;
-            else Origin = {...Origin, ...Val};
+            if (!Property) Origin[Id] = Val;
+            else Origin[Key][Id] = Val;
             this.Cache.set(FieldId, Origin);
         }
 

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -153,28 +153,28 @@ class Selection {
     /**
      * Joins another Selection into this instance based on a referrer field.
      * Identical to the `FULL JOIN` SQL statement.
-     * @param {Selection} Sel Another Selection instance to join into this one.
+     * @param {Selection} Secondary Another Selection instance to join into this one.
      * @param {String} Field Which field to check for a reference to this Selection's rows.
-     * @param {String} Attachment The name where all the entries should be stored in this Selection.
+     * @param {Boolean|String} [Property] Boolean false to flatten the entries into this Selection's rows,
+     * a string value that implicitly indicates the property to add the merging entries,
+     * or a boolean true to use the Selection's table name as property.
      * @returns {Selection}
      */
-    Join (Sel, Field, Attachment) {
-        if (!(Sel instanceof Selection))    return null;
-        if (typeof Field !== "string")      return null;
-        if (typeof Attachment !== "string") return null;
+    Join (Secondary, Field, Property = true) {
+        if (!(Secondary instanceof Selection)) return null;
+        if (typeof Field !== "string")         return null;
 
-        this.Map(Entry => {
-            Entry[Attachment] = {};
-            return Entry;
-        });
+        const Key = typeof Property === "string" ? Property : Secondary.Holds;
+        if (Property) this.Map(Entry => { Entry[Key] = {}; return Entry; });
 
-        for (const [Key, Val] of Sel.Cache) {
-            const Id = Val[Field];
-            const Origin = this.Cache.get(Id);
+        for (const [Id, Val] of Secondary.Cache) {
+            const FieldId = Val[Field];
+            let Origin = this.Cache.get(FieldId);
             if (!Origin) continue;
 
-            Origin[Attachment][Key] = Val;
-            this.Cache.set(Id, Origin);
+            if (Property) Origin[Key][Id] = Val;
+            else Origin = {...Origin, ...Val};
+            this.Cache.set(FieldId, Origin);
         }
 
         return this;


### PR DESCRIPTION
This PR introduces the `Join()` method for the Selection class. As this is identical to a SQL `FULL JOIN`, it merges two Selections into the origin based on a field in the secondary Selection.

The `Property` argument tells the method in which property field you'd like the secondary Selection's rows to merge into. Either this is `false` to flatten it into the origin, a string for a custom name as a collector, or boolean `true` to use the table name which represents the Selection.

Lastly, I implemented v8's serialisation API to deep clone the Selection for the `Clone()` function.