### PR TITLE
Initial version of QDB Shell

### DIFF
--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -8,7 +8,7 @@ const Arguments = process.argv.slice(2);
 if (!Arguments.length) {
 
     const Commands = FS.readdirSync(__dirname + "/Store/")
-    .map(C => C.split(".")[0].toLowerCase());
+    .map(C => C.split(".")[0]);
 
     console.log(["QDB Shell\n",
         `${Format.BOLD("USAGE")}\n  qdb <database> [\"make\" | flags]\n`,

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+"use strict";
+
+const Format    = require("./Format");
+const Arguments = process.argv.slice(2);
+
+if (!Arguments.length) {
+    
+    const FS = require("fs");
+    const Commands = FS.readdirSync("Shell/Store/")
+    .map(C => C.split(".")[0].toLowerCase());
+
+    console.log(["QDB Shell\n",
+        `${Format.BOLD("USAGE")}\n  qdb <database> [\"make\" | flags]\n`,
+        `${Format.BOLD("MENU")}\n  ${Format.LIST(Object.fromEntries(
+            Commands.map(Cmd => [Cmd, require(`./Store/${Cmd}`).Description])
+        ))}\n`,
+        `${Format.BOLD("REPOSITORY")}\n  https://github.com/QSmally/QDB`
+    ].join("\n"));
+
+} else {}

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 "use strict";
 
+const FS        = require("fs");
 const Format    = require("./Format");
 const Arguments = process.argv.slice(2);
 
 if (!Arguments.length) {
-    
-    const FS = require("fs");
+
     const Commands = FS.readdirSync("Shell/Store/")
     .map(C => C.split(".")[0].toLowerCase());
 
@@ -23,7 +23,6 @@ if (!Arguments.length) {
     let Make = Arguments.map(A => A.toLowerCase()).findIndex(V => V === "make");
     if (Make !== -1) Arguments.splice(Make, 1), Make = true;
 
-    const FS   = require("fs");
     const Path = Arguments[0];
 
     if (!FS.existsSync(Path)) {

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -14,7 +14,7 @@ if (!Arguments.length) {
         `${Format.BOLD("USAGE")}\n  qdb <database> [\"make\" | flags]\n`,
         `${Format.BOLD("MENU")}\n${Format.LIST(Object.fromEntries(
             Commands.map(Cmd => [Cmd, require(`./Store/${Cmd}`).Description])
-        ))}\n`,
+        ), 18)}\n`,
         `${Format.BOLD("REPOSITORY")}\n  https://github.com/QSmally/QDB`
     ].join("\n"));
 

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -18,4 +18,23 @@ if (!Arguments.length) {
         `${Format.BOLD("REPOSITORY")}\n  https://github.com/QSmally/QDB`
     ].join("\n"));
 
-} else {}
+} else {
+
+    let Make = Arguments.map(A => A.toLowerCase()).findIndex(V => V === "make");
+    if (Make !== -1) Arguments.splice(Make, 1), Make = true;
+
+    const FS   = require("fs");
+    const Path = Arguments[0];
+
+    if (!FS.existsSync(Path)) {
+        if (Make !== true) {
+            console.log([`${Format.BOLD("Error")}: ${Path} does not exist.`,
+                "If you wish to create the database, include `make` in the command."
+            ].join("\n"));
+            process.exit(0);
+        }
+
+        FS.appendFileSync(Path, "");
+    }
+
+}

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -12,7 +12,7 @@ if (!Arguments.length) {
 
     console.log(["QDB Shell\n",
         `${Format.BOLD("USAGE")}\n  qdb <database> [\"make\" | flags]\n`,
-        `${Format.BOLD("MENU")}\n  ${Format.LIST(Object.fromEntries(
+        `${Format.BOLD("MENU")}\n${Format.LIST(Object.fromEntries(
             Commands.map(Cmd => [Cmd, require(`./Store/${Cmd}`).Description])
         ))}\n`,
         `${Format.BOLD("REPOSITORY")}\n  https://github.com/QSmally/QDB`

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -18,6 +18,8 @@ if (!Arguments.length) {
         `${Format.BOLD("REPOSITORY")}\n  https://github.com/QSmally/QDB`
     ].join("\n"));
 
+    process.exit(0);
+
 } else {
 
     let Make = Arguments.map(A => A.toLowerCase()).findIndex(V => V === "make");
@@ -30,6 +32,7 @@ if (!Arguments.length) {
             console.log([`${Format.BOLD("Error")}: ${Path} does not exist.`,
                 "If you wish to create the database, include `make` in the command."
             ].join("\n"));
+
             process.exit(0);
         }
 

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -36,4 +36,6 @@ if (!Arguments.length) {
         FS.appendFileSync(Path, "");
     }
 
+    require("./Menu")(Path);
+
 }

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -7,7 +7,7 @@ const Arguments = process.argv.slice(2);
 
 if (!Arguments.length) {
 
-    const Commands = FS.readdirSync("Shell/Store/")
+    const Commands = FS.readdirSync(__dirname + "/Store/")
     .map(C => C.split(".")[0].toLowerCase());
 
     console.log(["QDB Shell\n",

--- a/Shell/Format.js
+++ b/Shell/Format.js
@@ -4,6 +4,6 @@ const C = {BOLD: "\x1b[1m", RESET: "\x1b[0m"};
 module.exports = {
     BOLD: Text => `${C.BOLD}${Text}${C.RESET}`,
     LIST: Items => Object.keys(Items)
-        .map(Item => `  ${Item}:`.padEnd(8) + Items[Item])
+        .map(Item => `  ${Item}:`.padEnd(18) + Items[Item])
         .join("\n")
 }

--- a/Shell/Format.js
+++ b/Shell/Format.js
@@ -1,3 +1,9 @@
 
 const C = {BOLD: "\x1b[1m", RESET: "\x1b[0m"};
-module.exports = Text => `${C.BOLD}${Text}${C.RESET}`;
+
+module.exports = {
+    BOLD: Text => `${C.BOLD}${Text}${C.RESET}`,
+    LIST: Items => Object.keys(Items)
+        .map(Item => `  ${Item}:`.padEnd(8) + Items[Item])
+        .join("\n")
+}

--- a/Shell/Format.js
+++ b/Shell/Format.js
@@ -1,0 +1,3 @@
+
+const C = {BOLD: "\x1b[1m", RESET: "\x1b[0m"};
+module.exports = Text => `${C.BOLD}${Text}${C.RESET}`;

--- a/Shell/Format.js
+++ b/Shell/Format.js
@@ -3,7 +3,7 @@ const C = {BOLD: "\x1b[1m", RESET: "\x1b[0m"};
 
 module.exports = {
     BOLD: Text => `${C.BOLD}${Text}${C.RESET}`,
-    LIST: Items => Object.keys(Items)
-        .map(Item => `  ${Item}:`.padEnd(18) + Items[Item])
+    LIST: (Items, Padding) => Object.keys(Items)
+        .map(Item => `  ${Item}:`.padEnd(Padding) + Items[Item])
         .join("\n")
 }

--- a/Shell/Main.js
+++ b/Shell/Main.js
@@ -1,1 +1,0 @@
-#!/usr/bin/env node

--- a/Shell/Main.js
+++ b/Shell/Main.js
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/Shell/Main.js
+++ b/Shell/Main.js
@@ -1,1 +1,1 @@
-#!/usr/bin/env bash
+#!/usr/bin/env node

--- a/Shell/Menu.js
+++ b/Shell/Menu.js
@@ -3,7 +3,7 @@ module.exports = async Path => {
 
     const Selected = await require("./Prompts/Select").run();
     const Command  = require(`./Store/${Selected}`);
-    const Table    = Command.Input ? await require("./Prompts/Table").run() : null;
+    const Table    = Command.Input ? await require("./Prompts/Table")(Command.Action) : null;
 
     return Command.Execute(Path, Table);
 

--- a/Shell/Menu.js
+++ b/Shell/Menu.js
@@ -1,0 +1,10 @@
+
+module.exports = async Path => {
+
+    const Selected = await require("./Prompts/Select").run();
+    const Command  = require(`./Store/${Selected}`);
+    const Table    = Command.Input ? await require("./Prompts/Table").run() : null;
+
+    return Command.Execute(Path, Table);
+
+}

--- a/Shell/Prompts/Select.js
+++ b/Shell/Prompts/Select.js
@@ -1,0 +1,11 @@
+
+const FS       = require("fs");
+const {Select} = require("enquirer");
+
+const Prompt = new Select({
+    name:    "Action",
+    message: "Select which action you would like to perform",
+    choices: [...FS.readdirSync("Shell/Store/").map(C => C.split(".")[0])]
+});
+
+module.exports = Prompt;

--- a/Shell/Prompts/Select.js
+++ b/Shell/Prompts/Select.js
@@ -5,7 +5,7 @@ const {Select} = require("enquirer");
 const Prompt = new Select({
     name:    "Action",
     message: "Select which action you would like to perform",
-    choices: [...FS.readdirSync("Shell/Store/").map(C => C.split(".")[0])]
+    choices: [...FS.readdirSync(__dirname + "/../Store/").map(C => C.split(".")[0])]
 });
 
 module.exports = Prompt;

--- a/Shell/Prompts/Table.js
+++ b/Shell/Prompts/Table.js
@@ -1,0 +1,11 @@
+
+const {Input} = require("enquirer");
+
+module.exports = Action => {
+    const Prompt = new Input({
+        name:    "Table",
+        message: `What is the name of the table you would like to ${Action}?`
+    });
+
+    return Prompt;
+}

--- a/Shell/Prompts/Table.js
+++ b/Shell/Prompts/Table.js
@@ -7,5 +7,5 @@ module.exports = Action => {
         message: `What is the name of the table you would like to ${Action}?`
     });
 
-    return Prompt;
+    return Prompt.run();
 }

--- a/Shell/Store/Create-table.js
+++ b/Shell/Store/Create-table.js
@@ -1,0 +1,10 @@
+
+module.exports = {
+    Input:       true,
+    Action:      "create",
+    Description: "Creates a table in the given database file.",
+
+    Execute: (Path, Table) => {
+        console.log([Path, Table]);
+    }
+};

--- a/Shell/Store/Create-table.js
+++ b/Shell/Store/Create-table.js
@@ -1,10 +1,23 @@
 
+const Format = require("../Format");
+const SQL    = require("better-sqlite3");
+
 module.exports = {
     Input:       true,
     Action:      "create",
     Description: "Creates a table in the given database file.",
 
     Execute: (Path, Table) => {
-        console.log([Path, Table]);
+
+        const Connection = new SQL(Path);
+        
+        const ExistingTable = Connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(Table);
+        if (ExistingTable) return console.log(`${Format.BOLD("Error")}: another table exists with the name '${Table}'.`);
+
+        Connection.exec(`CREATE TABLE '${Table}' ('Key' VARCHAR PRIMARY KEY, 'Val' TEXT);`);
+        console.log(`Successfully created table '${Format.BOLD(Table)}'.`);
+
+        return true;
+
     }
 };

--- a/Shell/Store/Create-table.js
+++ b/Shell/Store/Create-table.js
@@ -16,6 +16,7 @@ module.exports = {
 
         Connection.exec(`CREATE TABLE '${Table}' ('Key' VARCHAR PRIMARY KEY, 'Val' TEXT);`);
         console.log(`Successfully created table '${Format.BOLD(Table)}'.`);
+        Connection.close();
 
         return true;
 

--- a/Shell/Store/List-tables.js
+++ b/Shell/Store/List-tables.js
@@ -1,0 +1,24 @@
+
+const Format = require("../Format");
+const SQL    = require("better-sqlite3");
+
+module.exports = {
+    Input:       false,
+    Action:      "list",
+    Description: "Lists all the tables in this database file.",
+
+    Execute: Path => {
+
+        const Connection = new SQL(Path);
+        
+        const Tables = Connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table';").all()
+        .map(Row => Row.name).map(Table => [Table, Connection.prepare(`SELECT count(*) FROM '${Table}';`).get()["count(*)"]])
+        .map(Entry => [Format.BOLD(Entry[0]), `${Entry[1]} rows`]);
+
+        console.log(Format.LIST(Object.fromEntries(Tables), 20));
+        Connection.close();
+
+        return true;
+
+    }
+};

--- a/Shell/Store/List-tables.js
+++ b/Shell/Store/List-tables.js
@@ -15,7 +15,7 @@ module.exports = {
         .map(Row => Row.name).map(Table => [Table, Connection.prepare(`SELECT count(*) FROM '${Table}';`).get()["count(*)"]])
         .map(Entry => [Format.BOLD(Entry[0]), `${Entry[1]} rows`]);
 
-        console.log(Format.LIST(Object.fromEntries(Tables), 20));
+        console.log(Format.LIST(Object.fromEntries(Tables), 26));
         Connection.close();
 
         return true;

--- a/Shell/Store/Remove-table.js
+++ b/Shell/Store/Remove-table.js
@@ -1,0 +1,23 @@
+
+const Format = require("../Format");
+const SQL    = require("better-sqlite3");
+
+module.exports = {
+    Input:       true,
+    Action:      "delete",
+    Description: "Erases a table in the given database file.",
+
+    Execute: (Path, Table) => {
+
+        const Connection = new SQL(Path);
+        
+        const ExistingTable = Connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(Table);
+        if (!ExistingTable) return console.log(`${Format.BOLD("Error")}: there's no table with the name '${Table}'.`);
+
+        Connection.exec(`DROP TABLE '${Table}';`);
+        console.log(`Successfully erased table '${Format.BOLD(Table)}'.`);
+
+        return true;
+
+    }
+};

--- a/Shell/Store/Remove-table.js
+++ b/Shell/Store/Remove-table.js
@@ -16,6 +16,7 @@ module.exports = {
 
         Connection.exec(`DROP TABLE '${Table}';`);
         console.log(`Successfully erased table '${Format.BOLD(Table)}'.`);
+        Connection.close();
 
         return true;
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "docs": "gendocs Test/DocConf.json"
   },
   "bin": {
-    "qdb": "Shell/Main.js"
+    "qdb": "Shell/CLI.js"
   },
   "keywords": [
     "database",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "benchmark": "node Benchmark/Main.js",
     "docs": "gendocs Test/DocConf.json"
   },
+  "bin": {
+    "qdb": "Shell/Main.js"
+  },
   "keywords": [
     "database",
     "utility",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^7.1.1",
+    "enquirer": "^2.3.6",
     "qulity": "^1.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I've implemented a very basic CLI using the `Enquirer` module. QDB Shell allows you to create databases, add and remove tables, and also list them with the number of rows they currently have. As QDB is heading towards the end of its beta lifetime, it would be a good moment to introduce this utility to the public.

I have more features I'd like to implement in the future, such as renaming tables.

Lastly, any bug reports are welcome.