### PR TITLE
Refactor QDB to use camelCasing

### DIFF
--- a/Benchmark/Trials/Fetch.js
+++ b/Benchmark/Trials/Fetch.js
@@ -1,17 +1,17 @@
 
-module.exports = Connection => {
-    const Indexes = Connection.Indexes;
-    const Amount  = 1000 * 1000;
+module.exports = connection => {
+    const indexes = connection.indexes;
+    const amount  = 1000 * 1000;
 
-    const TStart = process.hrtime();
+    const tStart = process.hrtime();
 
-    for (let i = 0; i < Amount; i++) {
-        const Id = Indexes[Math.round(Math.random() * (Indexes.length - 1))];
-        Connection.Fetch(Id);
+    for (let i = 0; i < amount; i++) {
+        const id = indexes[Math.round(Math.random() * (indexes.length - 1))];
+        connection.fetch(id);
     }
 
     return {
-        TEnd: process.hrtime(TStart),
-        Amount
+        tEnd: process.hrtime(tStart),
+        amount
     };
 }

--- a/Benchmark/Trials/Find.js
+++ b/Benchmark/Trials/Find.js
@@ -1,22 +1,22 @@
 
-module.exports = Connection => {
-    const Indexes = Connection.Indexes;
-    const Pattern = 3;
+module.exports = connection => {
+    const indexes = connection.indexes;
+    const pattern = 3;
 
-    for (let i = 0; i < Indexes.length; i++) {
-        if (i % Pattern !== 0) continue;
-        Connection.Fetch(Indexes[i]);
+    for (let i = 0; i < indexes.length; i++) {
+        if (i % pattern !== 0) continue;
+        connection.fetch(indexes[i]);
     }
 
-    const Target = Connection.Fetch(Indexes[Indexes.length - 1]);
-    const TStart = process.hrtime();
+    const target = connection.fetch(indexes[indexes.length - 1]);
+    const tStart = process.hrtime();
 
-    Connection.Find(({Username, Password}) => {
-        return Username === Target.Username && Password === Target.Password;
+    connection.find(({ username, password }) => {
+        return username === target.username && password === target.password;
     });
 
     return {
-        TEnd: process.hrtime(TStart),
-        Amount: Connection.CacheSize
+        tEnd: process.hrtime(tStart),
+        amount: connection.cacheSize
     };
 }

--- a/Benchmark/Trials/Insert.js
+++ b/Benchmark/Trials/Insert.js
@@ -1,18 +1,17 @@
 
 const Crypto = require("crypto");
 
-module.exports = Connection => {
-    const Amount = 1000;
+module.exports = connection => {
+    const tStart = process.hrtime();
+    const amount = 1000;
 
-    const TStart = process.hrtime();
-
-    for (let i = 0; i < Amount; i++) {
-        const Id = Crypto.randomBytes(8).toString("hex");
-        Connection.Set(Id, {Test: "Insertion"});
+    for (let i = 0; i < amount; i++) {
+        const id = Crypto.randomBytes(8).toString("hex");
+        connection.set(id, { test: "Insertion" });
     }
 
     return {
-        TEnd: process.hrtime(TStart),
-        Amount
+        tEnd: process.hrtime(tStart),
+        amount
     };
 }

--- a/Benchmark/Trials/Selection.js
+++ b/Benchmark/Trials/Selection.js
@@ -1,13 +1,13 @@
 
-module.exports = Connection => {
-    const TStart = process.hrtime();
+module.exports = connection => {
+    const tStart = process.hrtime();
 
-    const Selection = Connection.Select(User => {
-        return User.Username === "Amy";
+    const selection = connection.select(user => {
+        return user.username === "Amy";
     });
 
     return {
-        TEnd: process.hrtime(TStart),
-        Amount: Selection.Cache.size
+        tEnd: process.hrtime(tStart),
+        amount: selection.cache.size
     };
 }

--- a/Benchmark/Trials/Transaction.js
+++ b/Benchmark/Trials/Transaction.js
@@ -1,21 +1,20 @@
 
 const Crypto = require("crypto");
 
-module.exports = Connection => {
-    const Amount  = 1000;
+module.exports = connection => {
+    const tStart = process.hrtime();
+    const t = connection.transaction();
+    const amount  = 1000;
 
-    const TStart = process.hrtime();
-    const T = Connection.Transaction();
-
-    for (let i = 0; i < Amount; i++) {
-        const Id = Crypto.randomBytes(8).toString("hex");
-        Connection.Set(Id, {Test: "Transaction"});
+    for (let i = 0; i < amount; i++) {
+        const id = Crypto.randomBytes(8).toString("hex");
+        connection.set(id, { test: "Transaction" });
     }
 
-    T.Commit();
+    t.commit();
 
     return {
-        TEnd: process.hrtime(TStart),
-        Amount
+        tEnd: process.hrtime(tStart),
+        amount
     };
 }

--- a/Documentation/Connection.md
+++ b/Documentation/Connection.md
@@ -14,248 +14,248 @@
 
 The main interface for interacting with QDB.
 ```js
-const Users = new QDB.Connection("lib/Databases/Users.qdb");
+const users = new QDB.Connection("../Cellar/Users.qdb");
 ```
 
 | Key | Type | Description |
 | --- | --- | --- |
-| PathURL | Pathlike | Path to the database file of this Connection. |
-| RawOptions? | RawOptions | Options for this Connection. |
+| pathURL | Pathlike | Path to the database file of this Connection. |
+| rawOptions? | RawOptions | Options for this Connection. |
 
 
 
 # Values
-## [.State](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L20)
+## [.state](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L20)
 > Current state of this Connection. [**Read Only**]
 >
 > Type **{String}**
 
-## [.Path](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L32)
+## [.path](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L32)
 > Path string to the database. [**Read Only**]
 >
 > Type **{Pathlike}**
 
-## [.ValOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L43)
+## [.valOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L43)
 > Options for this Connection. [**Read Only**]
 >
 > Type **{RawOptions}**
 
-## [.Pool](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L67)
+## [.poolController](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L67)
 > Reference to the Pool this Connection was created in. [**Read Only**]
 >
 > Type **{Pool?}**
 
-## [.Table](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L78)
+## [.table](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L78)
 > Table name of this Connection. [**Read Only**]
 >
 > Type **{String}**
 
-## [.Size](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L139)
+## [.size](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L143)
 > Retrieves all the rows of this Connection.
 >
 > Type **{Number}**
 
-## [.CacheSize](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L150)
-> Retrieves all the in-memory cached rows of this Connection. Extension of what would be `<Connection>.Cache.size`, but checks for the ready state.
+## [.cacheSize](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L155)
+> Retrieves all the in-memory cached rows of this Connection. Extension of what would be `<Connection>.memory.size`, but checks for the ready state.
 >
 > Type **{Number}**
 
-## [.Indexes](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L161)
+## [.indexes](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L166)
 > Retrieves all the keys of this database table.
 >
 > Type **{Array}**
 
 # Methods
-## [.Disconnect()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L172)
+## [.disconnect()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L179)
 > Disconnects from this Connection, clears in-memory rows. Only run this method when you are exiting the program, or want to fully disconnect from this database.
 >
 > Returns **{Connection}** 
 
-## [.AsObject()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L274)
-> Converts this database's rows into an Object. To use dotaccess, use `Fetch` instead.
+## [.asObject()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L283)
+> Converts this database's rows into an Object. To use dotaccess, use `fetch` instead.
 >
 > Returns **{Object}** An object instance with the key/value pairs of this database.
 
-## [.ToIntegratedManager(Pathlike?, Holds?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L284)
+## [.toIntegratedManager(pathlike?, holds?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L296)
 > Converts this database, or a part of it using dotaccess, to a Manager instance.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Pathlike? | Pathlike | Optional dotaccess path pointing towards what to serialise. |
-> | Holds? | Function | Given optional class for which instance this Manager is for. |
+> | pathlike? | Pathlike | Optional dotaccess path pointing towards what to serialise. |
+> | holds? | Function | Given optional class for which instance this Manager is for. |
 >
 > Returns **[{Manager}](https://github.com/QSmally/Qulity/blob/master/Documentation/BaseManager.md)** A Manager instance with the key/model pairs.
 
-## [.Transaction()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L301)
+## [.transaction()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L317)
 > Creates a SQL transaction, which allows you to commit or rollback changes.
 >
 > Returns **{Transaction?}** A Transaction instance, or a nil value when already in a transaction.
 
-## [.Set(KeyOrPath, Value)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L314)
+## [.set(keyOrPath, document)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L330)
 > Manages the elements of the database.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies at what row to insert or replace the element at. Use dotaccess notation to edit properties. |
-> | Value | Object, Array, DataModel, Any | Data to set at the row address, at the location of the key or path. |
+> | keyOrPath | Pathlike | Specifies at what row to insert or replace the element at. Use dotaccess notation to edit properties. |
+> | document | Object, Array, DataModel, Any | Data to set at the row address, at the location of the key or path. |
 >
 > Returns **{Connection}** Returns the current Connection.
 
-## [.Fetch(KeyOrPath, Cache?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L337)
+## [.fetch(keyOrPath, cache?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L354)
 > Manages the retrieval of the database.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies which row to fetch or get from cache. Use dotaccess to retrieve properties. |
-> | Cache? | Boolean | Whether to, if not already, cache this entry in results that the next retrieval would be much faster. |
+> | keyOrPath | Pathlike | Specifies which row to fetch or get from cache. Use dotaccess to retrieve properties. |
+> | cache? | Boolean | Whether to, if not already, cache this entry in results that the next retrieval would be much faster. |
 >
 > Returns **{Object|Array|DataModel|Any}** Value of the row, or the property when using dotaccess.
 
-## [.Evict(Keys?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L365)
+## [.evict(keys?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L382)
 > Erases elements from this Connection's internal cache.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Keys? | ...Pathlike | A key or multiple keys to remove from cache. If none, the cache will get cleared entirely. |
+> | keys? | ...Pathlike | A key or multiple keys to remove from cache. If none, the cache will get cleared entirely. |
 >
 > Returns **{Connection}** Returns the current Connection.
 
-## [.Erase(Keys)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L382)
+## [.erase(keys)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L400)
 > Manages the deletion of the database.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Keys | ...Pathlike | A key or multiple keys to remove from the database. These elements will also get removed from this Connection's internal cache. |
+> | keys | ...Pathlike | A key or multiple keys to remove from the database. These elements will also get removed from this Connection's internal cache. |
 >
 > Returns **{Connection}** Returns the current Connection.
 
-## [.Exists(Key, Cache?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L407)
+## [.exists(key, cache?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L427)
 > Returns whether or not a row in this database exists. This method also caches the row internally, so fetching it afterwards would be much faster.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Key | Pathlike | Specifies which row to see if it exists. |
-> | Cache? | Boolean | Whether or not to cache the fetched entry. |
+> | key | Pathlike | Specifies which row to see if it exists. |
+> | cache? | Boolean | Whether or not to cache the fetched entry. |
 >
 > Returns **{Boolean}** Whether or not a row exists in this database.
 
-## [.Each(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L421)
+## [.each(method)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L442)
 > Iterates through this database's entries.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Fn | Function | A function which passes on the iterating entries. |
+> | method | Function | A function which passes on the iterating entries. |
 >
 > Returns **{Connection}** Returns the current Connection.
 
-## [.Find(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L436)
+## [.find(predicate)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L457)
 > Iterates through all the entries of the database, returns the first element found.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Fn | Function | A tester function which returns a boolean, based on the value(s) of the rows. |
+> | predicate | Function | A tester function which returns a boolean, based on the value(s) of the rows. |
 >
 > Returns **{Object|Array|DataModel}** Returns the row which was found, or a nil value.
 
-## [.Select(FnOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L457)
+## [.select(predicateOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L483)
 > Locally filters out rows in memory to work with. Please note that this method does increase memory usage in large databases.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | FnOrPath | Function, Pathlike | A filter function or a path to a row. |
+> | predicateOrPath | Function, Pathlike | A filter function or a path to a row. |
 >
 > Returns **{Selection}** A Selection class instance.
 
-## [.Push(KeyOrPath, Values)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L485)
+## [.push(keyOrPath, values)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L513)
 > Pushes something to an array at the path output.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies which row or nested array to push to. |
-> | Values | ...Any | Values to insert and push to this array. |
+> | keyOrPath | Pathlike | Specifies which row or nested array to push to. |
+> | values | ...Any | Values to insert and push to this array. |
 >
 > Returns **{Number}** New length of the array.
 
-## [.Shift(KeyOrPath, Values?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L504)
+## [.shift(keyOrPath, values?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L532)
 > Inserts (if defined) or removes a value to/from the front of the array.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies which row or nested array to insert to/remove from. |
-> | Values? | ...Any | If defined, inserts new values at the front of the array. |
+> | keyOrPath | Pathlike | Specifies which row or nested array to insert to/remove from. |
+> | values? | ...Any | If defined, inserts new values at the front of the array. |
 >
 > Returns **{Number|Any}** New length of the array if a value was inserted, or the shifted value.
 
-## [.Pop(KeyOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L527)
+## [.pop(keyOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L558)
 > Pops something from an array at the path output.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies which row or nested array to pop from. |
+> | keyOrPath | Pathlike | Specifies which row or nested array to pop from. |
 >
 > Returns **{Any}** Returns the popped value.
 
-## [.Remove(KeyOrPath, FnOrIdx)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L544)
+## [.remove(keyOrPath, predicateOrIdx)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L575)
 > Removes a specific element from this endpoint array.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies which row or nested array to remove a value from. |
-> | FnOrIdx | Function, Number | Function or an index that specifies which item to remove. |
+> | keyOrPath | Pathlike | Specifies which row or nested array to remove a value from. |
+> | predicateOrIdx | Function, Number | Function or an index that specifies which item to remove. |
 >
 > Returns **{Number}** New length of the array.
 
-## [.Slice(KeyOrPath, Start?, End?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L572)
+## [.slice(keyOrPath, startIdx?, endIdx?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L603)
 > Removes elements from this endpoint array based on indexes.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies which row or nested array to slice values from. |
-> | Start? | Number | Beginning of the specified portion of the array. |
-> | End? | Number | End of the specified portion of the array. |
+> | keyOrPath | Pathlike | Specifies which row or nested array to slice values from. |
+> | startIdx? | Number | Beginning of the specified portion of the array. |
+> | endIdx? | Number | End of the specified portion of the array. |
 >
 > Returns **{Number}** New length of the array.
 
-## [.Ensure(KeyOrPath, Input, Merge?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L594)
+## [.ensure(keyOrPath, input, merge?)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L625)
 > Inserts an input into a row or nested object if the key or path wasn't found at the endpoint. It can be used as a default schema of the database elements, that gets inserted if there's no entry already.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Context key to see if it exists, either a row or nested property, and optionally insert the new value. |
-> | Input | Object, Array, Schema, Any | A value to input if the row or nested property wasn't found in the database. |
-> | Merge? | Boolean | Whether or not to merge `Input` with this Connection's Schema model as initial values. |
+> | keyOrPath | Pathlike | Context key to see if it exists, either a row or nested property, and optionally insert the new value. |
+> | input | Object, Array, Schema, Any | A value to input if the row or nested property wasn't found in the database. |
+> | merge? | Boolean | Whether or not to merge `Input` with this Connection's Schema model as initial values. |
 >
 > Returns **{Boolean}** Whether or not the new value was inserted.
 
-## [.Modify(KeyOrPath, Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L621)
+## [.modify(keyOrPath, method)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L652)
 > Updates a value if the entry exists by fetching it and passing it onto the callback function.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies which row or nested property to fetch. |
-> | Fn | Function | Callback which includes the original value of the fetched row or property. |
+> | keyOrPath | Pathlike | Specifies which row or nested property to fetch. |
+> | method | Function | Callback which includes the original value of the fetched row or property. |
 >
 > Returns **{Object|Array|DataModel}** Returns the new row of the updated property.
 
-## [.Invert(KeyOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L645)
+## [.invert(keyOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L676)
 > Inverts a boolean, from true to false and vice-versa, at the endpoint of the path.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Specifies which row or nested property to boolean-invert. |
+> | keyOrPath | Pathlike | Specifies which row or nested property to boolean-invert. |
 >
 > Returns **{Boolean}** Returns the updated boolean value of the property.
 
 # Typedefs
-## [RawOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L664)
+## [RawOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L694)
 > Options for a database Connection. All integer related options are in milliseconds. 
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Table | String | A name for the table to use at this path for this Connection. |
-> | Schema | Schema | Link to a database Schema class for automatic data migration. |
+> | table | String | A name for the table to use at this path for this Connection. |
+> | schema | Schema | Link to a database Schema class for automatic data migration. |
 > | WAL | Boolean | Whether or not to enable Write Ahead Logging mode. |
-> | Queries | Function | A function that gets ran for each executed SQL query in QDB. |
-> | Cache | Boolean | Whether to enable in-memory caching of entries in results that the next retrieval would be much faster. |
-> | FetchAll | Boolean | Whether or not to fetch all the database entries on start-up of this database Connection. |
-> | UtilCache | Boolean | Whether or not to cache entries while performing utility tasks, such as the Exists method. |
-> | CacheMaxSize | Number | Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries. |
-> | SweepInterval | Number | Integer to indicate at what interval to sweep the entries of this Connection's internal cache. |
-> | SweepLifetime | Number | The minimum age of an entry in the cache to consider being sweepable after an interval. |
+> | queries | Function | A function that gets ran for each executed SQL query in QDB. |
+> | cache | Boolean | Whether to enable in-memory caching of entries in results that the next retrieval would be much faster. |
+> | fetchAll | Boolean | Whether or not to fetch all the database entries on start-up of this database Connection. |
+> | utilCache | Boolean | Whether or not to cache entries while performing utility tasks, such as the Exists method. |
+> | cacheMaxSize | Number | Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries. |
+> | sweepInterval | Number | Integer to indicate at what interval to sweep the entries of this Connection's internal cache. |
+> | sweepLifetime | Number | The minimum age of an entry in the cache to consider being sweepable after an interval. |
 >
 > Type **{Object}**
 
-## [DataModel](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L684)
+## [DataModel](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L714)
 > An entry which has been resolved from the Connection's internal cache.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | _Timestamp | Number | Timestamp when this entry was last patched. |
+> | _timestamp | Number | Timestamp when this entry was last patched. |
 >
 > Type **{Object|Array}**
 
-## [Pathlike](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L690)
+## [Pathlike](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Connection.js#L720)
 > Path string to navigate files.
 >
 > Type **{String}**

--- a/Documentation/Manager.md
+++ b/Documentation/Manager.md
@@ -15,66 +15,66 @@
 
 A utility class for creating backups of databases.
 ```js
-new QDB.BackupManager("lib/Databases/", { Destination: "/usr/local/backups/" });
+new QDB.BackupManager("../Cellar/", { destination: "/usr/local/backups/" });
 ```
 
 | Key | Type | Description |
 | --- | --- | --- |
-| PathURL | Pathlike | Path to the database file or directory to backup. |
-| BackupOptions | BackupOptions | Options to use for this Backup Manager. |
+| pathURL | Pathlike | Path to the database file or directory to backup. |
+| backupOptions | BackupOptions | Options to use for this Backup Manager. |
 
 
 
 # Values
-## [.Path](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L23)
+## [.path](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L22)
 > Path string to a directory or database file. [**Read Only**]
 >
 > Type **{Pathlike}**
 
-## [.Destination](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L52)
+## [.destination](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L51)
 > Path string to the destination of the backups. [**Read Only**]
 >
 > Type **{Pathlike}**
 
 # Methods
-## [.On(Event, Listener)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L95)
+## [.on(event, listener)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L93)
 > Registers an event listener on one of this Manager's events.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Event | String | Which action to register for the listener. |
-> | Listener | Function | Function to execute upon this event. |
+> | event | String | Which action to register for the listener. |
+> | listener | Function | Function to execute upon this event. |
 >
 > Returns **{BackupManager}** 
 
-## [.Spawn()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L106)
+## [.spawn()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L104)
 > Spawns the child process for this Manager.
 >
 > Returns **{BackupManager}** 
 
-## [.Exit()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L133)
-> Ends the backup process and emits the `Exit` event.
+## [.exit()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L131)
+> Ends the backup process and emits the `exit` event.
 >
 > Returns **{BackupManager}** 
 
 # Typedefs
-## [BackupOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L148)
+## [BackupOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L145)
 > Options for a Backup Manager. All integer related options are in milliseconds. 
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Retry | Boolean | Whether or not to retry spawning this Manager's child process if it exits with a non-zero code. |
-> | Destination | String | Path to the directory where backups will be placed in. |
-> | Interval | Number | A time interval for when copies of the database(s) will be created. |
-> | Snapshots | Number | Maximum amount of snapshots to create until making a full backup. |
+> | retry | Boolean | Whether or not to retry spawning this Manager's child process if it exits with a non-zero code. |
+> | destination | String | Path to the directory where backups will be placed in. |
+> | interval | Number | A time interval for when copies of the database(s) will be created. |
+> | snapshots | Number | Maximum amount of snapshots to create until making a full backup. |
 >
 > Type **{Object}**
 
-## [BackupEvents](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L160)
-> Events related to the BackupManager, registered by `Manager.On(...);`. 
+## [BackupEvents](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Backups/Manager.js#L157)
+> Events related to the BackupManager, registered by `manager.on(...);`. 
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Spawn | Timestamp | Fired upon a new child process being created for this Manager. |
-> | Exit | Number | Executed with the status code as argument of the function. |
-> | Error | Error | Fired when the child process encountered an error. |
-> | Debug | String | Any message from the backup process with information about its state. |
+> | spawn | Timestamp | Fired upon a new child process being created for this Manager. |
+> | exit | Number | Executed with the status code as argument of the function. |
+> | error | Error | Fired when the child process encountered an error. |
+> | debug | String | Any message from the backup process with information about its state. |
 >
 > Type **{Events}**

--- a/Documentation/Output.json
+++ b/Documentation/Output.json
@@ -1,7 +1,7 @@
 {
     "Connection": [
         {
-            "Value": "State",
+            "Value": "state",
             "Flags": [
                 "Variable",
                 "ReadOnly"
@@ -11,7 +11,7 @@
             "Type": "{String}"
         },
         {
-            "Value": "Path",
+            "Value": "path",
             "Flags": [
                 "Variable",
                 "ReadOnly"
@@ -21,7 +21,7 @@
             "Type": "{Pathlike}"
         },
         {
-            "Value": "ValOptions",
+            "Value": "valOptions",
             "Flags": [
                 "Variable",
                 "ReadOnly"
@@ -31,7 +31,7 @@
             "Type": "{RawOptions}"
         },
         {
-            "Value": "Pool",
+            "Value": "poolController",
             "Flags": [
                 "Variable",
                 "ReadOnly"
@@ -41,7 +41,7 @@
             "Type": "{Pool?}"
         },
         {
-            "Value": "Table",
+            "Value": "table",
             "Flags": [
                 "Variable",
                 "ReadOnly"
@@ -62,7 +62,7 @@
             "Reference": "https://github.com/JoshuaWise/better-sqlite3/blob/master/docs/api.md"
         },
         {
-            "Value": "Cache",
+            "Value": "memory",
             "Flags": [
                 "Variable",
                 "Private"
@@ -73,7 +73,7 @@
             "Reference": "https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md"
         },
         {
-            "Value": "_Executors",
+            "Value": "_executors",
             "Flags": [
                 "Variable",
                 "Private"
@@ -83,291 +83,291 @@
             "Type": "{Object}"
         },
         {
-            "Value": "Size",
+            "Value": "size",
             "Flags": [
                 "Variable"
             ],
-            "Line": 139,
+            "Line": 143,
             "Description": "Retrieves all the rows of this Connection.",
             "Action": "Getter",
-            "Refer": "Size",
+            "Refer": "size",
             "Type": "{Number}"
         },
         {
-            "Value": "CacheSize",
+            "Value": "cacheSize",
             "Flags": [
                 "Variable"
             ],
-            "Line": 150,
-            "Description": "Retrieves all the in-memory cached rows of this Connection. Extension of what would be `<Connection>.Cache.size`, but checks for the ready state.",
+            "Line": 155,
+            "Description": "Retrieves all the in-memory cached rows of this Connection. Extension of what would be `<Connection>.memory.size`, but checks for the ready state.",
             "Action": "Getter",
-            "Refer": "CacheSize",
+            "Refer": "cacheSize",
             "Type": "{Number}"
         },
         {
-            "Value": "Indexes",
+            "Value": "indexes",
             "Flags": [
                 "Variable"
             ],
-            "Line": 161,
+            "Line": 166,
             "Description": "Retrieves all the keys of this database table.",
             "Action": "Getter",
-            "Refer": "Indexes",
+            "Refer": "indexes",
             "Type": "{Array}"
         },
         {
-            "Value": "Disconnect",
+            "Value": "disconnect",
             "Flags": [],
-            "Line": 172,
+            "Line": 179,
             "Description": "Disconnects from this Connection, clears in-memory rows. Only run this method when you are exiting the program, or want to fully disconnect from this database.",
             "Returns": "{Connection}"
         },
         {
-            "Value": "_Ready",
+            "Value": "_ready",
             "Flags": [
                 "Variable",
                 "Private"
             ],
-            "Line": 191,
+            "Line": 198,
             "Description": "Internal getter. Checks whether this database is ready for execution.",
             "Action": "Getter",
-            "Refer": "_Ready",
+            "Refer": "_ready",
             "Type": "{Boolean}"
         },
         {
-            "Value": "_Resolve",
+            "Value": "_resolve",
             "Flags": [
                 "Private"
             ],
-            "Line": 202,
+            "Line": 209,
             "Description": "Internal method. Resolves a dotaccess path or key and parses it.",
             "Params": [
-                "{Pathlike} Pathlike String input to be formed and parsed."
+                "{Pathlike} pathlike String input to be formed and parsed."
             ],
-            "Returns": "{Array<String, Array?>} Array containnig a 'Key' and an optional 'Path'."
+            "Returns": "{Array<String, Array?>} Array containnig a 'key' and an optional 'path'."
         },
         {
-            "Value": "_Patch",
+            "Value": "_patch",
             "Flags": [
                 "Private"
             ],
-            "Line": 214,
+            "Line": 221,
             "Description": "Internal method. Inserts or patches something in this Connection's internal cache.",
             "Params": [
-                "{String|Number} Key As address to memory map this value to.",
-                "{Object|Array} Val The value to set in the memory cache."
+                "{String|Number} key As address to memory map this value to.",
+                "{Object|Array} document The value to set in the memory cache."
             ],
             "Returns": "{Collection} Returns the updated cache instance of this Connection.",
             "Reference": "https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md"
         },
         {
-            "Value": "_CastPath",
+            "Value": "_castPath",
             "Flags": [
                 "Private"
             ],
-            "Line": 235,
+            "Line": 242,
             "Description": "Internal method. Finds a relative dotaccess pathway of an object.",
             "Params": [
-                "{Object|Array} Frame The object-like beginning to cast.",
-                "{Array} Pathlike A dotaccess notation path as an Array. Preferred `Path` value from `_Resolve()`.",
-                "{*} [Item] A value to cast into the inputted frame object."
+                "{Object|Array} frame The object-like beginning to cast.",
+                "{Array} pathlike A dotaccess notation path as an Array. Preferred `Path` value from `_Resolve()`.",
+                "{*} [item] A value to cast into the inputted frame object."
             ],
             "Returns": "{*} Returns the output of the caster."
         },
         {
-            "Value": "AsObject",
+            "Value": "asObject",
             "Flags": [],
-            "Line": 274,
-            "Description": "Converts this database's rows into an Object. To use dotaccess, use `Fetch` instead.",
+            "Line": 283,
+            "Description": "Converts this database's rows into an Object. To use dotaccess, use `fetch` instead.",
             "Returns": "{Object} An object instance with the key/value pairs of this database."
         },
         {
-            "Value": "ToIntegratedManager",
+            "Value": "toIntegratedManager",
             "Flags": [],
-            "Line": 284,
+            "Line": 296,
             "Description": "Converts this database, or a part of it using dotaccess, to a Manager instance.",
             "Params": [
-                "{Pathlike} [Pathlike] Optional dotaccess path pointing towards what to serialise.",
-                "{Function} [Holds] Given optional class for which instance this Manager is for."
+                "{Pathlike} [pathlike] Optional dotaccess path pointing towards what to serialise.",
+                "{Function} [holds] Given optional class for which instance this Manager is for."
             ],
             "Returns": "{Manager} A Manager instance with the key/model pairs.",
             "Reference": "https://github.com/QSmally/Qulity/blob/master/Documentation/BaseManager.md"
         },
         {
-            "Value": "Transaction",
+            "Value": "transaction",
             "Flags": [],
-            "Line": 301,
+            "Line": 317,
             "Description": "Creates a SQL transaction, which allows you to commit or rollback changes.",
             "Returns": "{Transaction?} A Transaction instance, or a nil value when already in a transaction."
         },
         {
-            "Value": "Set",
+            "Value": "set",
             "Flags": [],
-            "Line": 314,
+            "Line": 330,
             "Description": "Manages the elements of the database.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies at what row to insert or replace the element at. Use dotaccess notation to edit properties.",
-                "{Object|Array|DataModel|*} Value Data to set at the row address, at the location of the key or path."
+                "{Pathlike} keyOrPath Specifies at what row to insert or replace the element at. Use dotaccess notation to edit properties.",
+                "{Object|Array|DataModel|*} document Data to set at the row address, at the location of the key or path."
             ],
             "Returns": "{Connection} Returns the current Connection."
         },
         {
-            "Value": "Fetch",
+            "Value": "fetch",
             "Flags": [],
-            "Line": 337,
+            "Line": 354,
             "Description": "Manages the retrieval of the database.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies which row to fetch or get from cache. Use dotaccess to retrieve properties.",
-                "{Boolean} [Cache] Whether to, if not already, cache this entry in results that the next retrieval would be much faster."
+                "{Pathlike} keyOrPath Specifies which row to fetch or get from cache. Use dotaccess to retrieve properties.",
+                "{Boolean} [cache] Whether to, if not already, cache this entry in results that the next retrieval would be much faster."
             ],
             "Returns": "{Object|Array|DataModel|*} Value of the row, or the property when using dotaccess."
         },
         {
-            "Value": "Evict",
-            "Flags": [],
-            "Line": 365,
-            "Description": "Erases elements from this Connection's internal cache.",
-            "Params": [
-                "{...Pathlike} [Keys] A key or multiple keys to remove from cache. If none, the cache will get cleared entirely."
-            ],
-            "Returns": "{Connection} Returns the current Connection."
-        },
-        {
-            "Value": "Erase",
+            "Value": "evict",
             "Flags": [],
             "Line": 382,
-            "Description": "Manages the deletion of the database.",
+            "Description": "Erases elements from this Connection's internal cache.",
             "Params": [
-                "{...Pathlike} Keys A key or multiple keys to remove from the database. These elements will also get removed from this Connection's internal cache."
+                "{...Pathlike} [keys] A key or multiple keys to remove from cache. If none, the cache will get cleared entirely."
             ],
             "Returns": "{Connection} Returns the current Connection."
         },
         {
-            "Value": "Exists",
+            "Value": "erase",
             "Flags": [],
-            "Line": 407,
+            "Line": 400,
+            "Description": "Manages the deletion of the database.",
+            "Params": [
+                "{...Pathlike} keys A key or multiple keys to remove from the database. These elements will also get removed from this Connection's internal cache."
+            ],
+            "Returns": "{Connection} Returns the current Connection."
+        },
+        {
+            "Value": "exists",
+            "Flags": [],
+            "Line": 427,
             "Description": "Returns whether or not a row in this database exists. This method also caches the row internally, so fetching it afterwards would be much faster.",
             "Params": [
-                "{Pathlike} Key Specifies which row to see if it exists.",
-                "{Boolean} [Cache] Whether or not to cache the fetched entry."
+                "{Pathlike} key Specifies which row to see if it exists.",
+                "{Boolean} [cache] Whether or not to cache the fetched entry."
             ],
             "Returns": "{Boolean} Whether or not a row exists in this database."
         },
         {
-            "Value": "Each",
+            "Value": "each",
             "Flags": [],
-            "Line": 421,
+            "Line": 442,
             "Description": "Iterates through this database's entries.",
             "Params": [
-                "{Function} Fn A function which passes on the iterating entries."
+                "{Function} method A function which passes on the iterating entries."
             ],
             "Returns": "{Connection} Returns the current Connection."
         },
         {
-            "Value": "Find",
+            "Value": "find",
             "Flags": [],
-            "Line": 436,
+            "Line": 457,
             "Description": "Iterates through all the entries of the database, returns the first element found.",
             "Params": [
-                "{Function} Fn A tester function which returns a boolean, based on the value(s) of the rows."
+                "{Function} predicate A tester function which returns a boolean, based on the value(s) of the rows."
             ],
             "Returns": "{Object|Array|DataModel} Returns the row which was found, or a nil value."
         },
         {
-            "Value": "Select",
+            "Value": "select",
             "Flags": [],
-            "Line": 457,
+            "Line": 483,
             "Description": "Locally filters out rows in memory to work with. Please note that this method does increase memory usage in large databases.",
             "Params": [
-                "{Function|Pathlike} FnOrPath A filter function or a path to a row."
+                "{Function|Pathlike} predicateOrPath A filter function or a path to a row."
             ],
             "Returns": "{Selection} A Selection class instance."
         },
         {
-            "Value": "Push",
+            "Value": "push",
             "Flags": [],
-            "Line": 485,
+            "Line": 513,
             "Description": "Pushes something to an array at the path output.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies which row or nested array to push to.",
-                "{...Any} Values Values to insert and push to this array."
+                "{Pathlike} keyOrPath Specifies which row or nested array to push to.",
+                "{...Any} values Values to insert and push to this array."
             ],
             "Returns": "{Number} New length of the array."
         },
         {
-            "Value": "Shift",
+            "Value": "shift",
             "Flags": [],
-            "Line": 504,
+            "Line": 532,
             "Description": "Inserts (if defined) or removes a value to/from the front of the array.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies which row or nested array to insert to/remove from.",
-                "{...Any} [Values] If defined, inserts new values at the front of the array."
+                "{Pathlike} keyOrPath Specifies which row or nested array to insert to/remove from.",
+                "{...Any} [values] If defined, inserts new values at the front of the array."
             ],
             "Returns": "{Number|*} New length of the array if a value was inserted, or the shifted value."
         },
         {
-            "Value": "Pop",
+            "Value": "pop",
             "Flags": [],
-            "Line": 527,
+            "Line": 558,
             "Description": "Pops something from an array at the path output.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies which row or nested array to pop from."
+                "{Pathlike} keyOrPath Specifies which row or nested array to pop from."
             ],
             "Returns": "{*} Returns the popped value."
         },
         {
-            "Value": "Remove",
+            "Value": "remove",
             "Flags": [],
-            "Line": 544,
+            "Line": 575,
             "Description": "Removes a specific element from this endpoint array.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies which row or nested array to remove a value from.",
-                "{Function|Number} FnOrIdx Function or an index that specifies which item to remove."
+                "{Pathlike} keyOrPath Specifies which row or nested array to remove a value from.",
+                "{Function|Number} predicateOrIdx Function or an index that specifies which item to remove."
             ],
             "Returns": "{Number} New length of the array."
         },
         {
-            "Value": "Slice",
+            "Value": "slice",
             "Flags": [],
-            "Line": 572,
+            "Line": 603,
             "Description": "Removes elements from this endpoint array based on indexes.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies which row or nested array to slice values from.",
-                "{Number} [Start] Beginning of the specified portion of the array.",
-                "{Number} [End] End of the specified portion of the array."
+                "{Pathlike} keyOrPath Specifies which row or nested array to slice values from.",
+                "{Number} [startIdx] Beginning of the specified portion of the array.",
+                "{Number} [endIdx] End of the specified portion of the array."
             ],
             "Returns": "{Number} New length of the array."
         },
         {
-            "Value": "Ensure",
+            "Value": "ensure",
             "Flags": [],
-            "Line": 594,
+            "Line": 625,
             "Description": "Inserts an input into a row or nested object if the key or path wasn't found at the endpoint. It can be used as a default schema of the database elements, that gets inserted if there's no entry already.",
             "Params": [
-                "{Pathlike} KeyOrPath Context key to see if it exists, either a row or nested property, and optionally insert the new value.",
-                "{Object|Array|Schema|*} Input A value to input if the row or nested property wasn't found in the database.",
-                "{Boolean} [Merge] Whether or not to merge `Input` with this Connection's Schema model as initial values."
+                "{Pathlike} keyOrPath Context key to see if it exists, either a row or nested property, and optionally insert the new value.",
+                "{Object|Array|Schema|*} input A value to input if the row or nested property wasn't found in the database.",
+                "{Boolean} [merge] Whether or not to merge `Input` with this Connection's Schema model as initial values."
             ],
             "Returns": "{Boolean} Whether or not the new value was inserted."
         },
         {
-            "Value": "Modify",
+            "Value": "modify",
             "Flags": [],
-            "Line": 621,
+            "Line": 652,
             "Description": "Updates a value if the entry exists by fetching it and passing it onto the callback function.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies which row or nested property to fetch.",
-                "{Function} Fn Callback which includes the original value of the fetched row or property."
+                "{Pathlike} keyOrPath Specifies which row or nested property to fetch.",
+                "{Function} method Callback which includes the original value of the fetched row or property."
             ],
             "Returns": "{Object|Array|DataModel} Returns the new row of the updated property."
         },
         {
-            "Value": "Invert",
+            "Value": "invert",
             "Flags": [],
-            "Line": 645,
+            "Line": 676,
             "Description": "Inverts a boolean, from true to false and vice-versa, at the endpoint of the path.",
             "Params": [
-                "{Pathlike} KeyOrPath Specifies which row or nested property to boolean-invert."
+                "{Pathlike} keyOrPath Specifies which row or nested property to boolean-invert."
             ],
             "Returns": "{Boolean} Returns the updated boolean value of the property."
         },
@@ -376,20 +376,20 @@
             "Flags": [
                 "Typedef"
             ],
-            "Line": 664,
+            "Line": 694,
             "Description": "Options for a database Connection. All integer related options are in milliseconds. ",
             "Typedef": "{Object} RawOptions",
             "Params": [
-                "{String} Table A name for the table to use at this path for this Connection.",
-                "{Schema} Schema Link to a database Schema class for automatic data migration.",
+                "{String} table A name for the table to use at this path for this Connection.",
+                "{Schema} schema Link to a database Schema class for automatic data migration.",
                 "{Boolean} WAL Whether or not to enable Write Ahead Logging mode. ",
-                "{Function} Queries A function that gets ran for each executed SQL query in QDB. ",
-                "{Boolean} Cache Whether to enable in-memory caching of entries in results that the next retrieval would be much faster.",
-                "{Boolean} FetchAll Whether or not to fetch all the database entries on start-up of this database Connection.",
-                "{Boolean} UtilCache Whether or not to cache entries while performing utility tasks, such as the Exists method. ",
-                "{Number} CacheMaxSize Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries.",
-                "{Number} SweepInterval Integer to indicate at what interval to sweep the entries of this Connection's internal cache.",
-                "{Number} SweepLifetime The minimum age of an entry in the cache to consider being sweepable after an interval."
+                "{Function} queries A function that gets ran for each executed SQL query in QDB. ",
+                "{Boolean} cache Whether to enable in-memory caching of entries in results that the next retrieval would be much faster.",
+                "{Boolean} fetchAll Whether or not to fetch all the database entries on start-up of this database Connection.",
+                "{Boolean} utilCache Whether or not to cache entries while performing utility tasks, such as the Exists method. ",
+                "{Number} cacheMaxSize Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries.",
+                "{Number} sweepInterval Integer to indicate at what interval to sweep the entries of this Connection's internal cache.",
+                "{Number} sweepLifetime The minimum age of an entry in the cache to consider being sweepable after an interval."
             ]
         },
         {
@@ -397,11 +397,11 @@
             "Flags": [
                 "Typedef"
             ],
-            "Line": 684,
+            "Line": 714,
             "Description": "An entry which has been resolved from the Connection's internal cache.",
             "Typedef": "{Object|Array} DataModel",
             "Params": [
-                "{Number} _Timestamp Timestamp when this entry was last patched."
+                "{Number} _timestamp Timestamp when this entry was last patched."
             ]
         },
         {
@@ -409,57 +409,57 @@
             "Flags": [
                 "Typedef"
             ],
-            "Line": 690,
+            "Line": 720,
             "Description": "Path string to navigate files.",
             "Typedef": "{String} Pathlike"
         }
     ],
     "Pool": [
         {
-            "Value": "Path",
+            "Value": "path",
             "Flags": [
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 17,
+            "Line": 16,
             "Description": "Path string to the Pool directory.",
             "Type": "{Pathlike}"
         },
         {
-            "Value": "Store",
+            "Value": "store",
             "Flags": [
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 28,
+            "Line": 27,
             "Description": "A collection of databases this Pool holds.",
             "Type": "{Collection}",
             "Reference": "https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md"
         },
         {
-            "Value": "ValOptions",
+            "Value": "valOptions",
             "Flags": [
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 40,
+            "Line": 39,
             "Description": "Options for this Pool.",
             "Type": "{PoolOptions}"
         },
         {
-            "Value": "Select",
+            "Value": "select",
             "Flags": [],
-            "Line": 69,
+            "Line": 67,
             "Description": "Retrieves a database Connection from this Pool instance.",
             "Params": [
-                "{String} Base Reference link to the Connection to resolve."
+                "{String} base Reference link to the Connection to resolve."
             ],
             "Returns": "{Connection}"
         },
         {
-            "Value": "Disconnect",
+            "Value": "disconnect",
             "Flags": [],
-            "Line": 79,
+            "Line": 78,
             "Description": "Disconnects from all the Connections in this Pool.",
             "Returns": "{Pool}"
         },
@@ -468,95 +468,95 @@
             "Flags": [
                 "Typedef"
             ],
-            "Line": 94,
+            "Line": 93,
             "Description": "Options for a database Pool. All integer related options are in milliseconds. ",
             "Typedef": "{Object} PoolOptions",
             "Params": [
-                "{Object<Identifier, RawOptions>} Exclusives Non-default options to use for certain Connections to a database.",
-                "{Boolean} Binding Whether or not to automatically bind Schemas with the table names in the Pool. ",
+                "{Object<Identifier, RawOptions>} exclusives Non-default options to use for certain Connections to a database.",
+                "{Boolean} binding Whether or not to automatically bind Schemas with the table names in the Pool. ",
                 "{Boolean} WAL Default setting to enable Write Ahead Logging mode for Connections in this Pool.",
-                "{Boolean} Cache Whether to enable in-memory caching of entries in results that the next retrieval would be much faster.",
-                "{Boolean} UtilCache Whether or not to cache entries while performing utility tasks, such as the Exists method. ",
-                "{Number} CacheMaxSize Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries.",
-                "{Number} SweepInterval Integer to indicate at what interval to sweep the entries of the Connection's internal cache.",
-                "{Number} SweepLifetime The minimum age of an entry in the cache to consider being sweepable after an interval."
+                "{Boolean} cache Whether to enable in-memory caching of entries in results that the next retrieval would be much faster.",
+                "{Boolean} utilCache Whether or not to cache entries while performing utility tasks, such as the Exists method. ",
+                "{Number} cacheMaxSize Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries.",
+                "{Number} sweepInterval Integer to indicate at what interval to sweep the entries of the Connection's internal cache.",
+                "{Number} sweepLifetime The minimum age of an entry in the cache to consider being sweepable after an interval."
             ]
         }
     ],
     "Manager": [
         {
-            "Value": "Path",
+            "Value": "path",
             "Flags": [
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 23,
+            "Line": 22,
             "Description": "Path string to a directory or database file.",
             "Type": "{Pathlike}"
         },
         {
-            "Value": "ValOptions",
+            "Value": "valOptions",
             "Flags": [
                 "Variable",
                 "Private"
             ],
-            "Line": 34,
+            "Line": 33,
             "Description": "Options for this Manager.",
             "Type": "{BackupOptions}"
         },
         {
-            "Value": "Destination",
+            "Value": "destination",
             "Flags": [
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 52,
+            "Line": 51,
             "Description": "Path string to the destination of the backups.",
             "Type": "{Pathlike}"
         },
         {
-            "Value": "_Process",
+            "Value": "_process",
             "Flags": [
                 "Variable",
                 "Private"
             ],
-            "Line": 68,
+            "Line": 67,
             "Description": "The child process that manages the backups.",
             "Type": "{Process?}"
         },
         {
-            "Value": "_EventEmitter",
+            "Value": "_eventEmitter",
             "Flags": [
                 "Variable",
                 "Private"
             ],
-            "Line": 79,
+            "Line": 78,
             "Description": "This manager's event manager to control the information of the backup child process.",
             "Type": "{EventEmitter}"
         },
         {
-            "Value": "On",
+            "Value": "on",
             "Flags": [],
-            "Line": 95,
+            "Line": 93,
             "Description": "Registers an event listener on one of this Manager's events.",
             "Params": [
-                "{String} Event Which action to register for the listener.",
-                "{Function} Listener Function to execute upon this event."
+                "{String} event Which action to register for the listener.",
+                "{Function} listener Function to execute upon this event."
             ],
             "Returns": "{BackupManager}"
         },
         {
-            "Value": "Spawn",
+            "Value": "spawn",
             "Flags": [],
-            "Line": 106,
+            "Line": 104,
             "Description": "Spawns the child process for this Manager.",
             "Returns": "{BackupManager}"
         },
         {
-            "Value": "Exit",
+            "Value": "exit",
             "Flags": [],
-            "Line": 133,
-            "Description": "Ends the backup process and emits the `Exit` event.",
+            "Line": 131,
+            "Description": "Ends the backup process and emits the `exit` event.",
             "Returns": "{BackupManager}"
         },
         {
@@ -564,14 +564,14 @@
             "Flags": [
                 "Typedef"
             ],
-            "Line": 148,
+            "Line": 145,
             "Description": "Options for a Backup Manager. All integer related options are in milliseconds. ",
             "Typedef": "{Object} BackupOptions",
             "Params": [
-                "{Boolean} Retry Whether or not to retry spawning this Manager's child process if it exits with a non-zero code. ",
-                "{String} Destination Path to the directory where backups will be placed in.",
-                "{Number} Interval A time interval for when copies of the database(s) will be created.",
-                "{Number} Snapshots Maximum amount of snapshots to create until making a full backup."
+                "{Boolean} retry Whether or not to retry spawning this Manager's child process if it exits with a non-zero code. ",
+                "{String} destination Path to the directory where backups will be placed in.",
+                "{Number} interval A time interval for when copies of the database(s) will be created.",
+                "{Number} snapshots Maximum amount of snapshots to create until making a full backup."
             ]
         },
         {
@@ -579,20 +579,20 @@
             "Flags": [
                 "Typedef"
             ],
-            "Line": 160,
-            "Description": "Events related to the BackupManager, registered by `Manager.On(...);`. ",
+            "Line": 157,
+            "Description": "Events related to the BackupManager, registered by `manager.on(...);`. ",
             "Typedef": "{Events} BackupEvents",
             "Params": [
-                "{Timestamp} Spawn Fired upon a new child process being created for this Manager.",
-                "{Number} Exit Executed with the status code as argument of the function.",
-                "{Error} Error Fired when the child process encountered an error.",
-                "{String} Debug Any message from the backup process with information about its state."
+                "{Timestamp} spawn Fired upon a new child process being created for this Manager.",
+                "{Number} exit Executed with the status code as argument of the function.",
+                "{Error} error Fired when the child process encountered an error.",
+                "{String} debug Any message from the backup process with information about its state."
             ]
         }
     ],
     "Schema": [
         {
-            "Value": "Model",
+            "Value": "model",
             "Flags": [
                 "Variable",
                 "ReadOnly"
@@ -602,7 +602,7 @@
             "Type": "{Object|Array}"
         },
         {
-            "Value": "_Serialiser",
+            "Value": "_serialiser",
             "Flags": [
                 "Variable",
                 "Private"
@@ -612,231 +612,221 @@
             "Type": "{Function?}"
         },
         {
-            "Value": "Serialise",
+            "Value": "serialise",
             "Flags": [
                 "Variable"
             ],
-            "Line": 49,
+            "Line": 48,
             "Description": "Serialises a supposed database entry to this Schema's rich DataModel, if this Schema was instantiated with a Serialiser method.",
             "Action": "Getter",
-            "Refer": "Serialise",
+            "Refer": "serialise",
             "Type": "{Function}"
         },
         {
             "Value": "Instance",
             "Flags": [],
-            "Line": 61,
+            "Line": 60,
             "Description": "Public method. Integrates an entry object and integrates them with this Schema's Model.",
             "Params": [
-                "{Object} Target The main entry to compare against and to merge changes into."
+                "{Object} target The main entry to compare against and to merge changes into."
             ],
             "Returns": "{Object} A merged data object based on this Schema's Model."
         }
     ],
     "Selection": [
         {
-            "Value": "Cache",
+            "Value": "cache",
             "Flags": [
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 17,
+            "Line": 16,
             "Description": "Cached dataset of this Selection.",
             "Type": "{Collection}",
             "Reference": "https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md"
         },
         {
-            "Value": "Holds",
+            "Value": "holds",
             "Flags": [
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 32,
+            "Line": 31,
             "Description": "Reference to the table this Selection holds.",
             "Type": "{String}"
         },
         {
-            "Value": "Keys",
+            "Value": "keys",
             "Flags": [
                 "Variable"
             ],
-            "Line": 46,
+            "Line": 44,
             "Description": "Serialises this Selection's keys into an array.",
             "Action": "Getter",
-            "Refer": "Keys",
+            "Refer": "keys",
             "Type": "{Array}"
         },
         {
-            "Value": "Values",
+            "Value": "values",
             "Flags": [
                 "Variable"
             ],
-            "Line": 55,
+            "Line": 53,
             "Description": "Serialises this Selection's values into an array.",
             "Action": "Getter",
-            "Refer": "Values",
+            "Refer": "values",
             "Type": "{Array}"
         },
         {
-            "Value": "AsObject",
+            "Value": "asObject",
             "Flags": [
                 "Variable"
             ],
-            "Line": 64,
+            "Line": 62,
             "Description": "Serialises this Selection into an object.",
             "Action": "Getter",
-            "Refer": "AsObject",
+            "Refer": "asObject",
             "Type": "{Object}"
         },
         {
-            "Value": "Retrieve",
+            "Value": "retrieve",
             "Flags": [],
-            "Line": 74,
+            "Line": 72,
             "Description": "Returns the given document by its key from this Selection.",
             "Params": [
-                "{Pathlike} KeyOrPath Indicates which (nested) element to receieve."
+                "{Pathlike} keyOrPath Indicates which (nested) element to receieve."
             ],
             "Returns": "{Object|Array|DataModel}"
         },
         {
-            "Value": "_CastPath",
+            "Value": "_castPath",
             "Flags": [
                 "Private"
             ],
-            "Line": 91,
+            "Line": 89,
             "Description": "Internal method. Finds a relative dotaccess pathway of an object.",
             "Params": [
-                "{Object|Array} Frame The object-like beginning to cast.",
-                "{Array} Pathlike A dotaccess notation path, as an Array split by dots."
+                "{Object|Array} frame The object-like beginning to cast.",
+                "{Array} pathlike A dotaccess notation path, as an Array split by dots."
             ],
             "Returns": "{*} Returns the output of the caster."
         },
         {
-            "Value": "Order",
+            "Value": "order",
             "Flags": [],
-            "Line": 116,
+            "Line": 114,
             "Description": "Sorts this Selection's values. Identical to the `ORDER BY` SQL statement.",
             "Params": [
-                "{Function} Fn Function that determines the sort order with given arguments `a` and `b`."
+                "{Function} predicate Function that determines the sort order with given arguments `a` and `b`."
             ],
             "Returns": "{Selection}"
         },
         {
-            "Value": "OrderBy",
+            "Value": "filter",
             "Flags": [],
-            "Line": 128,
-            "Description": "Sorts this Selection's values. Identical to the `ORDER BY ... [DESC]` SQL statement.",
-            "Params": [
-                "{Function} Fn Function that determines which number to order by."
-            ],
-            "Returns": "{Selection}"
-        },
-        {
-            "Value": "Filter",
-            "Flags": [],
-            "Line": 144,
+            "Line": 126,
             "Description": "Filters values that satisfy the provided function. Identical to the `FILTER BY` SQL statement.",
             "Params": [
-                "{Function} Fn Function that determines which entries to keep."
+                "{Function} predicate Function that determines which entries to keep."
             ],
             "Returns": "{Selection}"
         },
         {
-            "Value": "Limit",
+            "Value": "limit",
             "Flags": [],
-            "Line": 160,
+            "Line": 144,
             "Description": "Slices off values from this Selection. Identical to the `LIMIT` SQL statement.",
             "Params": [
-                "{Number} Begin Index that indicates the beginning to slice.",
-                "{Number} [End] An index for the end of the slice."
+                "{Number} begin Index that indicates the beginning to slice.",
+                "{Number} [end] An index for the end of the slice."
             ],
             "Returns": "{Selection}"
         },
         {
-            "Value": "Group",
+            "Value": "group",
             "Flags": [],
-            "Line": 183,
+            "Line": 167,
             "Description": "Groups this Selection based on an identifier. Identical to the `GROUP BY` SQL statement.",
             "Params": [
-                "{Pathlike} KeyOrPath Determines by which property to group this Selection."
+                "{Pathlike} keyOrPath Determines by which property to group this Selection."
             ],
             "Returns": "{Selection}"
         },
         {
-            "Value": "Join",
+            "Value": "join",
             "Flags": [],
-            "Line": 210,
+            "Line": 194,
             "Description": "Joins another Selection into this instance based on a referrer field. Identical to the `FULL JOIN` SQL statement.",
             "Params": [
-                "{Selection} Secondary Another Selection instance to join into this one.",
-                "{String} Field Which field to check for a reference to this Selection's rows, or `null` to join with keys.",
-                "{Boolean|String} [Property] Boolean false to flatten the entries into this Selection's rows, a string value that implicitly indicates the property to add the merging entries, or a boolean true to use the Selection's table name as property."
+                "{Selection} secondary Another Selection instance to join into this one.",
+                "{String} field Which field to check for a reference to this Selection's rows, or `null` to join with keys.",
+                "{Boolean|String} [property] Boolean false to flatten the entries into this Selection's rows, a string value that implicitly indicates the property to add the merging entries, or a boolean true to use the Selection's table name as property."
             ],
             "Returns": "{Selection}"
         },
         {
-            "Value": "Map",
+            "Value": "map",
             "Flags": [],
-            "Line": 243,
+            "Line": 228,
             "Description": "Iterates over this Selection's values and keys, and implements the new values returned from the callback.",
             "Params": [
-                "{Function} Fn Callback function which determines the new values of the Selection."
+                "{Function} fn Callback function which determines the new values of the Selection."
             ],
             "Returns": "{Selection}"
         },
         {
-            "Value": "Merge",
+            "Value": "merge",
             "Flags": [],
-            "Line": 258,
+            "Line": 243,
             "Description": "Automatically clones the merging Selections and adds them into this instance.",
             "Params": [
-                "{...Selection} Selections Instances to clone and merge into this one."
+                "{...Selection} selections Instances to clone and merge into this one."
             ],
             "Returns": "{Selection}"
         },
         {
-            "Value": "Clone",
+            "Value": "clone",
             "Flags": [],
-            "Line": 273,
+            "Line": 258,
             "Description": "Creates a new memory allocation for the copy of this Selection.",
             "Params": [
-                "{String} [Holds] Optional new identifier value for the cloned Selection."
+                "{String} [holds] Optional new identifier value for the cloned Selection."
             ],
             "Returns": "{Selection}"
         }
     ],
     "Transaction": [
         {
-            "Value": "_Connection",
+            "Value": "_connection",
             "Flags": [
                 "Variable",
                 "Private"
             ],
-            "Line": 13,
+            "Line": 12,
             "Description": "Transaction's Connection reference.",
             "Type": "{Connection}"
         },
         {
-            "Value": "Active",
+            "Value": "active",
             "Flags": [
                 "Variable",
                 "ReadOnly"
             ],
-            "Line": 23,
+            "Line": 22,
             "Description": "Whether this Transaction is active.",
             "Type": "{Boolean}"
         },
         {
-            "Value": "Commit",
+            "Value": "commit",
             "Flags": [],
-            "Line": 40,
+            "Line": 38,
             "Description": "Publishes the changes made during this Transaction.",
             "Returns": "{Boolean} Whether the changed were committed."
         },
         {
-            "Value": "Rollback",
+            "Value": "rollback",
             "Flags": [],
-            "Line": 54,
+            "Line": 52,
             "Description": "Rolls back the changes made before the start of this Transaction. This also clears the contents of the Connection's internal cache.",
             "Returns": "{Boolean} Whether the changed were reset."
         }

--- a/Documentation/Pool.md
+++ b/Documentation/Pool.md
@@ -14,58 +14,58 @@
 
 A utility class for managing multiple database Connections.
 ```js
-const MyDBs = new QDB.Pool("lib/Databases/");
+const myDBs = new QDB.Pool("/usr/Production/Cellar/");
 ```
 
 | Key | Type | Description |
 | --- | --- | --- |
-| PathURL | Pathlike | Path to the database file or directory for this Pool to operate. |
-| PoolOptions? | PoolOptions | Options for this Pool to manage, including separate Connection options. |
+| pathURL | Pathlike | Path to the database file or directory for this Pool to operate. |
+| poolOptions? | PoolOptions | Options for this Pool to manage, including separate Connection options. |
 
 
 
 # Values
-## [.Path](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L17)
+## [.path](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L16)
 > Path string to the Pool directory. [**Read Only**]
 >
 > Type **{Pathlike}**
 
-## [.Store](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L28)
+## [.store](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L27)
 > A collection of databases this Pool holds. [**Read Only**]
 >
 > Type **[{Collection}](https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md)**
 
-## [.ValOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L40)
+## [.valOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L39)
 > Options for this Pool. [**Read Only**]
 >
 > Type **{PoolOptions}**
 
 # Methods
-## [.Select(Base)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L69)
+## [.select(base)](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L67)
 > Retrieves a database Connection from this Pool instance.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Base | String | Reference link to the Connection to resolve. |
+> | base | String | Reference link to the Connection to resolve. |
 >
 > Returns **{Connection}** 
 
-## [.Disconnect()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L79)
+## [.disconnect()](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L78)
 > Disconnects from all the Connections in this Pool.
 >
 > Returns **{Pool}** 
 
 # Typedefs
-## [PoolOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L94)
+## [PoolOptions](https://github.com/QSmally/QDB/blob/v4/lib/Connections/Pool.js#L93)
 > Options for a database Pool. All integer related options are in milliseconds. 
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Exclusives | Object<Identifier, RawOptions> | Non-default options to use for certain Connections to a database. |
-> | Binding | Boolean | Whether or not to automatically bind Schemas with the table names in the Pool. |
+> | exclusives | Object<Identifier, RawOptions> | Non-default options to use for certain Connections to a database. |
+> | binding | Boolean | Whether or not to automatically bind Schemas with the table names in the Pool. |
 > | WAL | Boolean | Default setting to enable Write Ahead Logging mode for Connections in this Pool. |
-> | Cache | Boolean | Whether to enable in-memory caching of entries in results that the next retrieval would be much faster. |
-> | UtilCache | Boolean | Whether or not to cache entries while performing utility tasks, such as the Exists method. |
-> | CacheMaxSize | Number | Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries. |
-> | SweepInterval | Number | Integer to indicate at what interval to sweep the entries of the Connection's internal cache. |
-> | SweepLifetime | Number | The minimum age of an entry in the cache to consider being sweepable after an interval. |
+> | cache | Boolean | Whether to enable in-memory caching of entries in results that the next retrieval would be much faster. |
+> | utilCache | Boolean | Whether or not to cache entries while performing utility tasks, such as the Exists method. |
+> | cacheMaxSize | Number | Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries. |
+> | sweepInterval | Number | Integer to indicate at what interval to sweep the entries of the Connection's internal cache. |
+> | sweepLifetime | Number | The minimum age of an entry in the cache to consider being sweepable after an interval. |
 >
 > Type **{Object}**

--- a/Documentation/Schema.md
+++ b/Documentation/Schema.md
@@ -16,30 +16,30 @@ A generic model that entries of a database automatically follows.
 
 | Key | Type | Description |
 | --- | --- | --- |
-| Id | String | An identifier for this Schema Model. |
-| Model | Object, Array | An object or array, giving the layout and default values of entries. |
-| Serialiser? | Function | A transformer object to implement, as a utility to fetch from some type of API or DataModel. |
+| identifier | String | An identifier for this Schema Model. |
+| model | Object, Array | An object or array, giving the layout and default values of entries. |
+| serialiser? | Function | A transformer object to implement, as a utility to fetch from some type of API or DataModel. |
 
 Schema Models are mainly used for automatic data migrations - For instance, adding or removing default data parts of each entry in the database. Include the `-m` command line option when starting the program to instantiate a migration.
 
 
 
 # Values
-## [.Model](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Schema.js#L21)
+## [.model](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Schema.js#L21)
 > The default model of this Schema. [**Read Only**]
 >
 > Type **{Object|Array}**
 
-## [.Serialise](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Schema.js#L49)
+## [.serialise](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Schema.js#L48)
 > Serialises a supposed database entry to this Schema's rich DataModel, if this Schema was instantiated with a Serialiser method.
 >
 > Type **{Function}**
 
 # Methods
-## [.Instance(Target)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Schema.js#L61)
+## [.Instance(target)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Schema.js#L60)
 > Public method. Integrates an entry object and integrates them with this Schema's Model.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Target | Object | The main entry to compare against and to merge changes into. |
+> | target | Object | The main entry to compare against and to merge changes into. |
 >
 > Returns **{Object}** A merged data object based on this Schema's Model.

--- a/Documentation/Selection.md
+++ b/Documentation/Selection.md
@@ -22,111 +22,103 @@ A Selection allows you to filter something from the database, and perform method
 
 
 # Values
-## [.Cache](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L17)
+## [.cache](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L16)
 > Cached dataset of this Selection. [**Read Only**]
 >
 > Type **[{Collection}](https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md)**
 
-## [.Holds](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L32)
+## [.holds](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L31)
 > Reference to the table this Selection holds. [**Read Only**]
 >
 > Type **{String}**
 
-## [.Keys](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L46)
+## [.keys](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L44)
 > Serialises this Selection's keys into an array.
 >
 > Type **{Array}**
 
-## [.Values](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L55)
+## [.values](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L53)
 > Serialises this Selection's values into an array.
 >
 > Type **{Array}**
 
-## [.AsObject](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L64)
+## [.asObject](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L62)
 > Serialises this Selection into an object.
 >
 > Type **{Object}**
 
 # Methods
-## [.Retrieve(KeyOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L74)
+## [.retrieve(keyOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L72)
 > Returns the given document by its key from this Selection.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Indicates which (nested) element to receieve. |
+> | keyOrPath | Pathlike | Indicates which (nested) element to receieve. |
 >
 > Returns **{Object|Array|DataModel}** 
 
-## [.Order(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L116)
+## [.order(predicate)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L114)
 > Sorts this Selection's values. Identical to the `ORDER BY` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Fn | Function | Function that determines the sort order with given arguments `a` and `b`. |
+> | predicate | Function | Function that determines the sort order with given arguments `a` and `b`. |
 >
 > Returns **{Selection}** 
 
-## [.OrderBy(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L128)
-> Sorts this Selection's values. Identical to the `ORDER BY ... [DESC]` SQL statement.
-> | Key | Type | Description |
-> | --- | --- | --- |
-> | Fn | Function | Function that determines which number to order by. |
->
-> Returns **{Selection}** 
-
-## [.Filter(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L144)
+## [.filter(predicate)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L126)
 > Filters values that satisfy the provided function. Identical to the `FILTER BY` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Fn | Function | Function that determines which entries to keep. |
+> | predicate | Function | Function that determines which entries to keep. |
 >
 > Returns **{Selection}** 
 
-## [.Limit(Begin, End?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L160)
+## [.limit(begin, end?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L144)
 > Slices off values from this Selection. Identical to the `LIMIT` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Begin | Number | Index that indicates the beginning to slice. |
-> | End? | Number | An index for the end of the slice. |
+> | begin | Number | Index that indicates the beginning to slice. |
+> | end? | Number | An index for the end of the slice. |
 >
 > Returns **{Selection}** 
 
-## [.Group(KeyOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L183)
+## [.group(keyOrPath)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L167)
 > Groups this Selection based on an identifier. Identical to the `GROUP BY` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | KeyOrPath | Pathlike | Determines by which property to group this Selection. |
+> | keyOrPath | Pathlike | Determines by which property to group this Selection. |
 >
 > Returns **{Selection}** 
 
-## [.Join(Secondary, Field, Property?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L210)
+## [.join(secondary, field, property?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L194)
 > Joins another Selection into this instance based on a referrer field. Identical to the `FULL JOIN` SQL statement.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Secondary | Selection | Another Selection instance to join into this one. |
-> | Field | String | Which field to check for a reference to this Selection's rows, or `null` to join with keys. |
-> | Property? | Boolean, String | Boolean false to flatten the entries into this Selection's rows, a string value that implicitly indicates the property to add the merging entries, or a boolean true to use the Selection's table name as property. |
+> | secondary | Selection | Another Selection instance to join into this one. |
+> | field | String | Which field to check for a reference to this Selection's rows, or `null` to join with keys. |
+> | property? | Boolean, String | Boolean false to flatten the entries into this Selection's rows, a string value that implicitly indicates the property to add the merging entries, or a boolean true to use the Selection's table name as property. |
 >
 > Returns **{Selection}** 
 
-## [.Map(Fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L243)
+## [.map(fn)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L228)
 > Iterates over this Selection's values and keys, and implements the new values returned from the callback.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Fn | Function | Callback function which determines the new values of the Selection. |
+> | fn | Function | Callback function which determines the new values of the Selection. |
 >
 > Returns **{Selection}** 
 
-## [.Merge(Selections)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L258)
+## [.merge(selections)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L243)
 > Automatically clones the merging Selections and adds them into this instance.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Selections | ...Selection | Instances to clone and merge into this one. |
+> | selections | ...Selection | Instances to clone and merge into this one. |
 >
 > Returns **{Selection}** 
 
-## [.Clone(Holds?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L273)
+## [.clone(holds?)](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Selection.js#L258)
 > Creates a new memory allocation for the copy of this Selection.
 > | Key | Type | Description |
 > | --- | --- | --- |
-> | Holds? | String | Optional new identifier value for the cloned Selection. |
+> | holds? | String | Optional new identifier value for the cloned Selection. |
 >
 > Returns **{Selection}** 

--- a/Documentation/Transaction.md
+++ b/Documentation/Transaction.md
@@ -14,7 +14,7 @@
 
 A SQL transaction manager.
 ```js
-const Transaction = MyDB.Transaction();
+const transaction = myDB.transaction();
 ```
 
 Transactions should only be created in synchronous environments, as other data changed will also be included in the transaction - which can be rolled back, leading to unexpected results.
@@ -22,18 +22,18 @@ Transactions should only be created in synchronous environments, as other data c
 
 
 # Values
-## [.Active](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Transaction.js#L23)
+## [.active](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Transaction.js#L22)
 > Whether this Transaction is active. [**Read Only**]
 >
 > Type **{Boolean}**
 
 # Methods
-## [.Commit()](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Transaction.js#L40)
+## [.commit()](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Transaction.js#L38)
 > Publishes the changes made during this Transaction.
 >
 > Returns **{Boolean}** Whether the changed were committed.
 
-## [.Rollback()](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Transaction.js#L54)
+## [.rollback()](https://github.com/QSmally/QDB/blob/v4/lib/Utility/Transaction.js#L52)
 > Rolls back the changes made before the start of this Transaction. This also clears the contents of the Connection's internal cache.
 >
 > Returns **{Boolean}** Whether the changed were reset.

--- a/QDB.js
+++ b/QDB.js
@@ -22,9 +22,9 @@ module.exports = {
 
     Schema: DataSchema.Schema,
 
-    Model: Id => {
-        if (typeof Id !== "string") return null;
-        return DataSchema.ModelStore.resolve(Id);
+    model: id => {
+        if (typeof id !== "string") return null;
+        return DataSchema.modelStore.resolve(id);
     }
 
 };

--- a/README.md
+++ b/README.md
@@ -27,25 +27,25 @@ const QDB = require("qdatabase");
 ## [Connection](https://github.com/QSmally/QDB/blob/v4/Documentation/Connection.md)
 The main interface for interacting with QDB.
 ```js
-const MyDB = new QDB.Connection(Path, Options?);
+const myDB = new QDB.Connection(path, options?);
 ```
 
 ## [Transaction](https://github.com/QSmally/QDB/blob/v4/Documentation/Transaction.md)
 A SQL transaction manager.
 ```js
-const Transaction = MyDB.Transaction();
+const transaction = myDB.Transaction();
 // Perform changes in the database...
-Transaction.Commit(); // or
-Transaction.Rollback();
+transaction.commit(); // or
+transaction.rollback();
 ```
 
 ## [Selection](https://github.com/QSmally/QDB/blob/v4/Documentation/Selection.md)
 An unchanged piece of the database in memory.
 ```js
-const Users = Programmers.Select()
-.Join(Projects, "UserId", "Projects")
-.OrderBy(User => Object.keys(User.Projects).length)
-.Group("Rank");
+const users = programmers.select()
+    .join(projects, "UserId", "Projects")
+    .order(user => Object.keys(user.Projects).length, "descending")
+    .group("Rank");
 ```
 
 

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -1,31 +1,29 @@
 #!/usr/bin/env node
 "use strict";
 
-const FS        = require("fs");
+const { existsSync, readdirSync} = require("fs");
+
 const Format    = require("./Format");
-const Arguments = process.argv.slice(2);
+const arguments = process.argv.slice(2);
 
-const Menu = require("./Menu");
-const Help = require("./Prompt/Help");
+const menu = require("./Menu");
+const help = require("./Prompt/Help");
 
-if (!Arguments.length) {
-    Help();
+if (!arguments.length) {
+    help();
 } else {
-
-    const Commands = new Map(FS.readdirSync(`${__dirname}/Prompt/`)
+    const commands = new Map(readdirSync(`${__dirname}/Prompt/`)
         .map(C => [C.split(".")[0].toLowerCase(), require(`./Prompt/${C}`)])
     );
 
-    const Action = Arguments.shift();
-    const Executable = Commands.get(Action.toLowerCase());
-    if (Executable) return Executable(Arguments.shift());
-    
+    const action = arguments.shift();
+    const executable = commands.get(action.toLowerCase());
+    if (executable) return executable(arguments.shift());
 
-    if (!FS.existsSync(Action)) return console.log([
-        `${Format.DIM("Error")}: '${Action}' does not exist.`,
+    if (!existsSync(action)) return console.log([
+        `${Format.dim("Error")}: '${action}' does not exist.`,
         "Use 'qdb make <database>' to create a new database file."
     ].join("\n"));
 
-    Menu(Action, Arguments);
-
+    menu(action, arguments);
 }

--- a/Shell/CLI.js
+++ b/Shell/CLI.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 "use strict";
 
-const { existsSync, readdirSync} = require("fs");
+const { existsSync, readdirSync } = require("fs");
 
 const Format    = require("./Format");
 const arguments = process.argv.slice(2);

--- a/Shell/Format.js
+++ b/Shell/Format.js
@@ -1,14 +1,16 @@
 
-const C = {
-    DIM:   "\x1b[40m",
-    BOLD:  "\x1b[1m",
-    RESET: "\x1b[0m"
-};
+class CLIFormatter {
+    static formats = {
+        dim:   "\x1b[40m",
+        bold:  "\x1b[1m",
+        reset: "\x1b[0m"
+    };
 
-module.exports = {
-    DIM: Text => `${C.DIM}${Text}${C.RESET}`,
-    BOLD: Text => `${C.BOLD}${Text}${C.RESET}`,
-    LIST: (Items, Padding, Dashes) => Object.keys(Items)
-        .map(Item => `${Dashes ? " -" : " "} ${Item}:`.padEnd(Padding) + Items[Item])
-        .join("\n")
-};
+    static dim = text => `${CLIFormatter.formats.dim}${text}${CLIFormatter.formats.reset}`;
+    static bold = text => `${CLIFormatter.formats.bold}${text}${CLIFormatter.formats.reset}`;
+    static list = (items, padding, dashes) => Object.keys(items)
+        .map(item => `${dashes ? " -" : " "} ${item}:`.padEnd(padding) + items[item])
+        .join("\n");
+}
+
+module.exports = CLIFormatter;

--- a/Shell/Menu.js
+++ b/Shell/Menu.js
@@ -1,26 +1,30 @@
 
-const FS     = require("fs");
+const { readdirSync } = require("fs");
+
 const Format = require("./Format");
 
-const Commands = new Map(FS.readdirSync(`${__dirname}/Store/`)
+const commands = new Map(readdirSync(`${__dirname}/Store/`)
     .map(C => [C.split(".")[0].toLowerCase(), require(`./Store/${C}`)])
 );
 
-module.exports = (Path, Arguments) => {
+module.exports = (path, arguments) => {
+    const command = arguments.shift() || "list";
+    const executable = commands.get(command.toLowerCase());
 
-    const Command    = Arguments.shift() || "list";
-    const Executable = Commands.get(Command.toLowerCase());
+    if (executable) {
+        if (arguments.length !== executable.arguments)
+            return console.log(`${Format.dim("Error")}: expected ${executable.arguments} arguments, but received ${arguments.length}.`);
 
-    if (Executable) {
-        if (Arguments.length !== Executable.Arguments)
-        return console.log(`${Format.DIM("Error")}: expected ${Executable.Arguments} arguments, but received ${Arguments.length}.`);
-        try { return Executable.Execute(Path, Arguments); }
-        catch (Err) { return console.log(`${Format.DIM("Error")}: ${Err.message}`); }
+        try {
+            return executable.execute(path, arguments);
+        } catch (error) {
+            const issue = `${Format.dim("Error")}: ${error.message}`;
+            return console.log(issue);
+        }
     }
 
     console.log([
-        `${Format.DIM("Error")}: command '${Command}' does not exist.`,
+        `${Format.dim("Error")}: command '${command}' does not exist.`,
         "See a list of commands by invoking 'qdb help [command]'."
     ].join("\n"));
-
 }

--- a/Shell/Prompt/Help.js
+++ b/Shell/Prompt/Help.js
@@ -2,39 +2,39 @@
 const FS     = require("fs");
 const Format = require("../Format");
 
-const Commands = new Map(FS.readdirSync(`${__dirname}/../Store/`)
+const commands = new Map(FS.readdirSync(`${__dirname}/../Store/`)
     .map(C => [C.split(".")[0].toLowerCase(), require(`../Store/${C}`)])
 );
 
-module.exports = Command => {
-    if (!Command) return console.log(["QDB Shell\n",
-        Format.BOLD("USAGE"),
+module.exports = command => {
+    if (!command) return console.log(["QDB Shell\n",
+        Format.bold("USAGE"),
         "  $ qdb <database | make | help> [command] [parameters...]\n",
 
-        Format.BOLD("COMMANDS"),
-        `${Format.LIST(Object.fromEntries(
-            [...Commands.entries()].map(Entry => [Entry[0], Entry[1].Description])
+        Format.bold("COMMANDS"),
+        `${Format.list(Object.fromEntries(
+            [...commands.entries()].map(entry => [entry[0], entry[1].description])
         ), 12)}\n`,
 
-        Format.BOLD("EXAMPLES"),
+        Format.bold("EXAMPLES"),
         `${[
             "make Instances.qdb",
             "Development.qdb create Users",
             "Production.qdb vacuum"
         ].map(E => `  $ qdb ${E}`).join("\n")}\n`,
 
-        Format.BOLD("REPOSITORY"),
+        Format.bold("REPOSITORY"),
         "  https://github.com/QSmally/QDB"
     ].join("\n"));
 
-    const Fetched = Commands.get(Command.toLowerCase());
-    if (!Fetched) return console.log(`${Format.DIM("Error")}: command '${Command}' does not exist.`);
+    const fetchedCommand = commands.get(command.toLowerCase());
+    if (!fetchedCommand) return console.log(`${Format.dim("Error")}: command '${command}' does not exist.`);
 
     console.log([
-        `QDB Shell - ${Format.BOLD(Command)}`,
-        Format.DIM(Fetched.Usage),
-        `\n${Fetched.Description}\n`,
+        `QDB Shell - ${Format.bold(command)}`,
+        Format.dim(fetchedCommand.usage),
+        `\n${fetchedCommand.description}\n`,
         Format.BOLD("EXAMPLES"),
-        ...Fetched.Examples.map(E => `  $ ${E}`)
+        ...fetchedCommand.examples.map(E => `  $ ${E}`)
     ].join("\n"));
 }

--- a/Shell/Prompt/Make.js
+++ b/Shell/Prompt/Make.js
@@ -2,20 +2,20 @@
 const FS     = require("fs");
 const Format = require("../Format");
 
-module.exports = Database => {
-    if (!Database) return console.log([
-        `QDB Shell - ${Format.BOLD("make")}`,
+module.exports = database => {
+    if (!database) return console.log([
+        `QDB Shell - ${Format.bold("make")}`,
         "\nMakes a new, QDB-formatted database file at the given path.\n",
-        Format.BOLD("EXAMPLES"),
+        Format.bold("EXAMPLES"),
         "  qdb make Users.qdb",
-        "  qdb make ./Content/Guilds.qdb",
-        "  qdb make /usr/xy/Client.qdb"
+        "  qdb make ./Cellar/Guilds.qdb",
+        "  qdb make /usr/xy/Service.qdb"
     ].join("\n"));
-    
-    if (FS.existsSync(Database)) return console.log(
-        `${Format.DIM("Error")}: file '${Database}' already exists.`
+
+    if (FS.existsSync(database)) return console.log(
+        `${Format.dim("Error")}: file '${database}' already exists.`
     );
 
-    FS.appendFileSync(Database, "");
-    console.log(`${Format.DIM("Success")}: database '${Database}' has been created.`);
+    FS.appendFileSync(database, "");
+    console.log(`${Format.dim("Success")}: database file '${database}' has been created.`);
 }

--- a/Shell/Store/Create.js
+++ b/Shell/Store/Create.js
@@ -3,28 +3,26 @@ const Format = require("../Format");
 const SQL    = require("better-sqlite3");
 
 module.exports = {
-    Usage: "qdb <database> create <name>",
-    Description: "Adds an additional table in the given database file.",
-    Examples: [
+    usage: "qdb <database> create <name>",
+    description: "Adds an additional table in the given database file.",
+    examples: [
         "qdb Users.qdb create Users",
         "qdb ./Internal/Guilds.qdb create Profiles"
     ],
 
-    Arguments: 1,
+    arguments: 1,
 
-    Execute: (Path, Arguments) => {
-
-        const Connection = new SQL(Path);
-        const Table = Arguments.shift();
+    execute: (path, arguments) => {
+        const connection = new SQL(path);
+        const table = arguments.shift();
         
-        const ExistingTable = Connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(Table);
-        if (ExistingTable) return console.log(`${Format.DIM("Error")}: another table exists with the name '${Table}'.`);
+        const existingTable = connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(table);
+        if (existingTable) return console.log(`${Format.dim("Error")}: another table exists with the name '${table}'.`);
 
-        Connection.prepare(`CREATE TABLE '${Table}' ('Key' VARCHAR PRIMARY KEY, 'Val' TEXT);`).run();
-        console.log(`Successfully created table '${Format.BOLD(Table)}'.`);
-        Connection.close();
+        connection.prepare(`CREATE TABLE '${table}' ('Key' VARCHAR PRIMARY KEY, 'Val' TEXT);`).run();
+        console.log(`Successfully created table '${Format.bold(table)}'.`);
+        connection.close();
 
         return true;
-
     }
 };

--- a/Shell/Store/Erase.js
+++ b/Shell/Store/Erase.js
@@ -3,28 +3,26 @@ const Format = require("../Format");
 const SQL    = require("better-sqlite3");
 
 module.exports = {
-    Usage: "qdb <database> erase <name>",
-    Description: "Drops the table given by the name attribute.",
-    Examples: [
+    usage: "qdb <database> erase <name>",
+    description: "Drops the table given by the name attribute.",
+    examples: [
         "qdb Users.qdb erase Users",
         "qdb ./Internal/Guilds.qdb erase Profiles"
     ],
 
-    Arguments: 1,
+    arguments: 1,
 
-    Execute: (Path, Arguments) => {
+    execute: (path, arguments) => {
+        const connection = new SQL(path);
+        const table = arguments.shift();
 
-        const Connection = new SQL(Path);
-        const Table = Arguments.shift();
-        
-        const ExistingTable = Connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(Table);
-        if (!ExistingTable) return console.log(`${Format.DIM("Error")}: there's no table with the name '${Table}'.`);
+        const existingTable = connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(table);
+        if (!existingTable) return console.log(`${Format.dim("Error")}: there's no table with the name '${table}'.`);
 
-        Connection.prepare(`DROP TABLE '${Table}';`).run();
-        console.log(`Successfully erased table '${Format.BOLD(Table)}'.`);
-        Connection.close();
+        connection.prepare(`DROP TABLE '${table}';`).run();
+        console.log(`Successfully erased table '${Format.bold(table)}'.`);
+        connection.close();
 
         return true;
-
     }
 };

--- a/Shell/Store/Fetch.js
+++ b/Shell/Store/Fetch.js
@@ -3,31 +3,29 @@ const Format = require("../Format");
 const SQL    = require("better-sqlite3");
 
 module.exports = {
-    Usage: "qdb <database> fetch <name> <identifier>",
-    Description: "Selects a table to fetch from and retrieves a document.",
-    Examples: [
+    usage: "qdb <database> fetch <name> <identifier>",
+    description: "Selects a table to fetch from and retrieves a document.",
+    examples: [
         "qdb Users.qdb fetch Users 2ff46929",
         "qdb ./Internal/Guilds.qdb fetch Profiles 396c9b85"
     ],
 
-    Arguments: 2,
+    arguments: 2,
 
-    Execute: (Path, Arguments) => {
+    execute: (path, arguments) => {
+        const connection = new SQL(path);
+        const table = arguments.shift();
 
-        const Connection = new SQL(Path);
-        const Table = Arguments.shift();
-        
-        const ExistingTable = Connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(Table);
-        if (!ExistingTable) return console.log(`${Format.DIM("Error")}: there's no table with the name '${Table}'.`);
+        const existingTable = connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(table);
+        if (!existingTable) return console.log(`${Format.dim("Error")}: there's no table with the name '${table}'.`);
 
-        const Identifier = Arguments.shift();
+        const identifier = arguments.shift();
 
-        const Document = Connection.prepare(`SELECT Val FROM '${Table}' WHERE Key = ?;`).get(Identifier);
-        if (!Document) console.log(`${Format.DIM("Error")}: unknown identifier '${Identifier}'.`);
-        else console.log(JSON.parse(Document.Val));
-        
-        Connection.close();
+        const documentObject = connection.prepare(`SELECT Val FROM '${table}' WHERE Key = ?;`).get(identifier);
+        if (!documentObject) console.log(`${Format.dim("Error")}: unknown identifier '${identifier}'.`);
+        else console.log(JSON.parse(documentObject.Val));
+
+        connection.close();
         return true;
-
     }
 };

--- a/Shell/Store/Rename.js
+++ b/Shell/Store/Rename.js
@@ -3,30 +3,28 @@ const Format = require("../Format");
 const SQL    = require("better-sqlite3");
 
 module.exports = {
-    Usage: "qdb <database> rename <name> <new-name>",
-    Description: "Alters the selected table and renames it to a given string.",
-    Examples: [
+    usage: "qdb <database> rename <name> <new-name>",
+    description: "Alters the selected table and renames it to a given string.",
+    examples: [
         "qdb Users.qdb rename Users Customers",
         "qdb ./Internal/Guilds.qdb rename Profiles Instances"
     ],
 
-    Arguments: 2,
+    arguments: 2,
 
-    Execute: async (Path, Arguments) => {
+    execute: async (path, arguments) => {
+        const connection = new SQL(path);
+        const table = arguments.shift();
 
-        const Connection = new SQL(Path);
-        const Table = Arguments.shift();
-        
-        const ExistingTable = Connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(Table);
-        if (!ExistingTable) return console.log(`${Format.DIM("Error")}: there's no table with the name '${Table}'.`);
+        const existingTable = connection.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table' AND name = ?;").get(table);
+        if (!existingTable) return console.log(`${Format.dim("Error")}: there's no table with the name '${table}'.`);
 
-        const Name = Arguments.shift();
+        const name = arguments.shift();
 
-        Connection.prepare(`ALTER TABLE '${Table}' RENAME TO '${Name}';`).run();
-        console.log(`Successfully renamed table '${Table}' to '${Format.BOLD(Name)}'.`);
-        Connection.close();
+        connection.prepare(`ALTER TABLE '${table}' RENAME TO '${name}';`).run();
+        console.log(`Successfully renamed table '${table}' to '${Format.bold(name)}'.`);
+        connection.close();
 
         return true;
-
     }
 };

--- a/Shell/Store/Vacuum.js
+++ b/Shell/Store/Vacuum.js
@@ -4,29 +4,27 @@ const Format = require("../Format");
 const SQL    = require("better-sqlite3");
 
 module.exports = {
-    Usage: "qdb <database> vacuum",
-    Description: "Rebuilds this database, repacking it into a minimal amount of disk space.",
-    Examples: [
+    usage: "qdb <database> vacuum",
+    description: "Rebuilds this database, repacking it into a minimal amount of disk space.",
+    examples: [
         "qdb Guilds.qdb vacuum",
     ],
 
-    Arguments: 0,
+    arguments: 0,
 
-    Execute: Path => {
-
-        const Connection = new SQL(Path);
-        const Size = FS.lstatSync(Path).size;
+    execute: path => {
+        const connection = new SQL(path);
+        const size = FS.lstatSync(path).size;
 
         process.stdout.write("Repacking database file... ");
-        Connection.prepare("VACUUM;").run();
-        Connection.close();
+        connection.prepare("VACUUM;").run();
+        connection.close();
 
-        const RepackedSize = Size - FS.lstatSync(Path).size;
-        const Units        = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
-        const Idx          = RepackedSize !== 0 ? Math.floor(Math.log(RepackedSize) / Math.log(1024)) : 0;
+        const repackedSize = size - FS.lstatSync(path).size;
+        const units        = ["bytes", "KiB", "MiB", "GiB", "TiB", "PiB"];
+        const idx          = repackedSize !== 0 ? Math.floor(Math.log(repackedSize) / Math.log(1024)) : 0;
 
-        console.log(`Successfully reclaimed ${Format.BOLD(`${Math.round(RepackedSize / Math.pow(1024, Idx))} ${Units[Idx]}`)} of disk space.`);
+        console.log(`Successfully reclaimed ${Format.bold(`${Math.round(repackedSize / Math.pow(1024, idx))} ${units[idx]}`)} of disk space.`);
         return true;
-
     }
 };

--- a/Test/Main.js
+++ b/Test/Main.js
@@ -1,43 +1,43 @@
 
 const QDB = require("../QDB");
-const Entries = {};
+const entries = {};
 
 try {
 
-    require("./Test")(QDB, (Name, Output, Expected) => {
-        Entries[Name] = {
-            Passed:   JSON.stringify(Output) == JSON.stringify(Expected),
-            Output:   Output,
-            Expected: Expected
+    require("./Test")(QDB, (name, output, expected) => {
+        entries[name] = {
+            passed:   JSON.stringify(output) == JSON.stringify(expected),
+            output:   output,
+            expected: expected
         };
     });
 
-    const Failed = [];
+    const failed = [];
 
-    for (const Key in Entries) {
-        if (!Entries[Key].Passed)
-        Failed.push({
-            Test:     Key,
-            Output:   Entries[Key].Output,
-            Expected: Entries[Key].Expected
+    for (const key in entries) {
+        if (!entries[key].passed)
+        failed.push({
+            test:     key,
+            output:   entries[key].output,
+            expected: entries[key].expected
         });
     }
 
-    console.log(`Successfully ran ${Object.keys(Entries).length} tests\nOf which ${Failed.length} have failed`);
+    console.log(`Successfully ran ${Object.keys(entries).length} tests\nOf which ${failed.length} have failed`);
 
-    if (Failed.length) {
+    if (failed.length) {
         console.log("Failed test stack:\n");
-        Failed.forEach(Entry => {
-            console.log(Entry.Test,
-                "\n", Entry.Output,
-                "\n", Entry.Expected
+        failed.forEach(entry => {
+            console.log(entry.test,
+                "\n", entry.output,
+                "\n", entry.expected
             );
         });
     }
 
-} catch (Err) {
+} catch (err) {
     console.error("Failed to run tests");
-    console.error(Err);
+    console.error(err);
 } finally {
-    if (process.argv.includes("-d")) console.debug(Entries);
+    if (process.argv.includes("-d")) console.debug(entries);
 }

--- a/Test/Test.js
+++ b/Test/Test.js
@@ -1,330 +1,331 @@
 
-module.exports = (QDB, Tap) => {
+module.exports = (QDB, tap) => {
+    const con = new QDB.Connection("Test/Users.qdb");
+    tap("Connection", con.state, "CONNECTED");
 
-    const Con = new QDB.Connection("Test/Users.qdb");
-    Tap("Connection", Con.State, "CONNECTED");
-
-    Con.Erase(...Con.Indexes);
-    Tap("Connection Clear 1", Con.Size, 0);
-    Tap("Connection Clear 2", Con.AsObject(), {});
+    con.erase(...con.indexes);
+    tap("Connection Clear 1", con.size, 0);
+    tap("Connection Clear 2", con.asObject(), {});
 
     // Base Connection functions
-    Tap("Connection Set 1", Con.Set("1234", {Name: "foo", Age: 26}).Size, 1);
-    Tap("Connection CacheSize 1", Con.CacheSize, 0);
-    Tap("Connection Set 2", Con.Set("2345", {Name: "bar", Age: 21}).Size, 2);
-    Tap("Connection CacheSize 2", Con.CacheSize, 0);
-    Tap("Connection Size 1", Con.Size, 2);
+    tap("Connection Set 1", con.set("1234", { name: "foo", age: 26 }).size, 1);
+    tap("Connection CacheSize 1", con.cacheSize, 0);
+    tap("Connection Set 2", con.set("2345", { name: "bar", age: 21 }).size, 2);
+    tap("Connection CacheSize 2", con.cacheSize, 0);
+    tap("Connection Size 1", con.size, 2);
 
-    Tap("Connection Fetch 1", Con.Fetch("2345"), {Name: "bar", Age: 21});
-    Tap("Connection CacheSize 3", Con.CacheSize, 1);
-    Tap("Connection Size 2", Con.Size, 2);
+    tap("Connection Fetch 1", con.fetch("2345"), { name: "bar", age: 21 });
+    tap("Connection CacheSize 3", con.cacheSize, 1);
+    tap("Connection Size 2", con.size, 2);
 
-    Tap("Connection Access 1", Con.Fetch("2345.Name"), "bar");
-    Tap("Connection Access 2", Con.Fetch("2345.Name.length"), 3);
-    Tap("Connection Access 3", Con.Fetch("2345.Age"), 21);
-    Tap("Connection Access 3", Con.Fetch("2345.Age.not.exists"), undefined);
-    Tap("Connection Access 4", Con.Fetch("2345.None"), undefined);
-    Tap("Connection Access 5", typeof Con.Fetch("2345._Timestamp"), "number");
-    Tap("Connection Access 6", Con.CacheSize, 1);
+    tap("Connection Access 1", con.fetch("2345.name"), "bar");
+    tap("Connection Access 2", con.fetch("2345.name.length"), 3);
+    tap("Connection Access 3", con.fetch("2345.age"), 21);
+    tap("Connection Access 3", con.fetch("2345.age.not.exists"), undefined);
+    tap("Connection Access 4", con.fetch("2345.none"), undefined);
+    tap("Connection Access 5", typeof con.fetch("2345._timestamp"), "number");
+    tap("Connection Access 6", con.cacheSize, 1);
 
-    Tap("Connection Fetch 2", Con.Fetch("1234"), {Name: "foo", Age: 26});
-    Tap("Connection CacheSize 4", Con.CacheSize, 2);
-    Tap("Connection Size 3", Con.Size, 2);
+    tap("Connection Fetch 2", con.fetch("1234"), { name: "foo", age: 26 });
+    tap("Connection CacheSize 4", con.cacheSize, 2);
+    tap("Connection Size 3", con.size, 2);
 
-    Tap("Connection Fetch 3", Con.Fetch("2345"), {Name: "bar", Age: 21});
-    Tap("Connection CacheSize 5", Con.CacheSize, 2);
-    Tap("Connection Size 4", Con.Size, 2);
+    tap("Connection Fetch 3", con.fetch("2345"), { name: "bar", age: 21 });
+    tap("Connection CacheSize 5", con.cacheSize, 2);
+    tap("Connection Size 4", con.size, 2);
 
-    Tap("Connection Evict 1", Con.Evict("2345").CacheSize, 1);
+    tap("Connection Evict 1", con.evict("2345").cacheSize, 1);
 
-    Tap("Connection Set 3", Con.Set("3456", {Name: "roo", Age: 29}).Size, 3);
-    Tap("Connection CacheSize 6", Con.CacheSize, 1);
-    Tap("Connection Set 4", Con.Set("4567", {Name: "goo", Age: 27}).Size, 4);
-    Tap("Connection CacheSize 7", Con.CacheSize, 1);
-    Tap("Connection Size 5", Con.Size, 4);
+    tap("Connection Set 3", con.set("3456", { name: "roo", age: 29 }).size, 3);
+    tap("Connection CacheSize 6", con.cacheSize, 1);
+    tap("Connection Set 4", con.set("4567", { name: "goo", age: 27 }).size, 4);
+    tap("Connection CacheSize 7", con.cacheSize, 1);
+    tap("Connection Size 5", con.size, 4);
 
-    Tap("Connection Fetch 4", Con.Fetch("3456"), {Name: "roo", Age: 29});
-    Tap("Connection Fetch 5", Con.Fetch("2345"), {Name: "bar", Age: 21});
-    Tap("Connection Fetch 6", Con.Fetch("1234"), {Name: "foo", Age: 26});
-    Tap("Connection Fetch 5", Con.Fetch("4567"), {Name: "goo", Age: 27});
-    Tap("Connection Evict 2", Con.Evict("2345", "3456").CacheSize, 2);
+    tap("Connection Fetch 4", con.fetch("3456"), { name: "roo", age: 29 });
+    tap("Connection Fetch 5", con.fetch("2345"), { name: "bar", age: 21 });
+    tap("Connection Fetch 6", con.fetch("1234"), { name: "foo", age: 26 });
+    tap("Connection Fetch 5", con.fetch("4567"), { name: "goo", age: 27 });
+    tap("Connection Evict 2", con.evict("2345", "3456").cacheSize, 2);
 
-    Tap("Connection Erase 1", Con.Erase("1234").Size, 3);
-    Tap("Connection CacheSize 8", Con.CacheSize, 1);
+    tap("Connection Erase 1", con.erase("1234").size, 3);
+    tap("Connection CacheSize 8", con.cacheSize, 1);
 
     // Lookup methods
-    Tap("Connection Exist 1", Con.Exists("1234"), false);
-    Tap("Connection Exist 2", Con.Exists("2345"), true);
-    Tap("Connection Exist 3", Con.Exists("6789"), false);
-    Tap("Connection CacheSize 9", Con.CacheSize, 2);
+    tap("Connection Exist 1", con.exists("1234"), false);
+    tap("Connection Exist 2", con.exists("2345"), true);
+    tap("Connection Exist 3", con.exists("6789"), false);
+    tap("Connection CacheSize 9", con.cacheSize, 2);
 
-    Tap("Connection Find 1", Con.Find((_e, i) => i.startsWith("34")), {Name: "roo", Age: 29});
-    Tap("Connection CacheSize 10", Con.CacheSize, 2);
+    tap("Connection Find 1", con.find((_e, i) => i.startsWith("34")), { name: "roo", age: 29 });
+    tap("Connection CacheSize 10", con.cacheSize, 2);
 
-    Tap("Connection Find 2", Con.Find((_e, i) => i === "1289"), undefined);
-    Tap("Connection CacheSize 11", Con.CacheSize, 2);
+    tap("Connection Find 2", con.find((_e, i) => i === "1289"), undefined);
+    tap("Connection CacheSize 11", con.cacheSize, 2);
 
-    Tap("Connection Find 3", Con.Find((_e, i) => i.startsWith("34")), {Name: "roo", Age: 29});
-    Tap("Connection CacheSize 12", Con.CacheSize, 2);
+    tap("Connection Find 3", con.find((_e, i) => i.startsWith("34")), { name: "roo", age: 29 });
+    tap("Connection CacheSize 12", con.cacheSize, 2);
 
-    Tap("Connection Evict 3", Con.Evict().CacheSize, 0);
+    tap("Connection Evict 3", con.evict().cacheSize, 0);
 
-    Tap("Connection Set 5", Con.Set("2345.Age", 30).Size, 3);
-    Tap("Connection Fetch 6", Con.Fetch("2345"), {Name: "bar", Age: 30});
+    tap("Connection Set 5", con.set("2345.age", 30).size, 3);
+    tap("Connection Fetch 6", con.fetch("2345"), { name: "bar", age: 30 });
 
     // Array methods
-    const IdxList = Con.Indexes;
-    for (const Idx in IdxList)
-    Tap(`Connection Set ${parseInt(Idx) + 6}`, Con.Set(`${IdxList[Idx]}.Hobbies`, []).Size, 3);
-    
-    Tap("Connection Push 1", Con.Push("3456", "wontWork"), null);
-    Tap("Connection Push 2", Con.Push("3456.Hobbies", "foo"), 1);
-    Tap("Connection Push 3", Con.Push("3456.Hobbies", "bar"), 2);
-    Tap("Connection Push 4", Con.Push("2345.Hobbies", "roo"), 1);
+    const idxList = con.indexes;
+    for (const idx in idxList)
+        tap(`Connection Set ${parseInt(idx) + 6}`, con.set(`${idxList[idx]}.hobbies`, []).size, 3);
 
-    Tap("Connection Pop 1", Con.Pop("3456"), null);
-    Tap("Connection Pop 2", Con.Pop("3456.Hobbies"), "bar");
-    Tap("Connection Pop 3", Con.Fetch("3456.Hobbies.length"), 1);
-    Tap("Connection Pop 4", Con.Pop("3456.Hobbies"), "foo");
-    Tap("Connection Pop 5", Con.Fetch("3456.Hobbies.length"), 0);
-    Tap("Connection Pop 6", Con.Pop("3456.Hobbies"), undefined);
-    Tap("Connection Pop 7", Con.Fetch("3456.Hobbies.length"), 0);
+    tap("Connection Push 1", con.push("3456", "wontWork"), null);
+    tap("Connection Push 2", con.push("3456.hobbies", "foo"), 1);
+    tap("Connection Push 3", con.push("3456.hobbies", "bar"), 2);
+    tap("Connection Push 4", con.push("2345.hobbies", "roo"), 1);
 
-    Tap("Connection Evict 4", Con.Evict("3456").CacheSize, 2);
+    tap("Connection Pop 1", con.pop("3456"), null);
+    tap("Connection Pop 2", con.pop("3456.hobbies"), "bar");
+    tap("Connection Pop 3", con.fetch("3456.hobbies.length"), 1);
+    tap("Connection Pop 4", con.pop("3456.hobbies"), "foo");
+    tap("Connection Pop 5", con.fetch("3456.hobbies.length"), 0);
+    tap("Connection Pop 6", con.pop("3456.hobbies"), undefined);
+    tap("Connection Pop 7", con.fetch("3456.hobbies.length"), 0);
 
-    Tap("Connection Push 5", Con.Push("3456.Hobbies", "goo"), 1);
-    Tap("Connection Push 6", Con.Push("3456.Hobbies", "loo"), 2);
+    tap("Connection Evict 4", con.evict("3456").cacheSize, 2);
 
-    Tap("Connection Remove 1", Con.Remove("3456", F => F === "goo"), null);
-    Tap("Connection Remove 2", Con.Remove("3456.Hobbies", F => F === "foo"), 2);
-    Tap("Connection Remove 3", Con.Remove("3456.Hobbies", 5), 2);
-    Tap("Connection Remove 4", Con.Remove("3456.Hobbies", 1), 1);
+    tap("Connection Push 5", con.push("3456.hobbies", "goo"), 1);
+    tap("Connection Push 6", con.push("3456.hobbies", "loo"), 2);
 
-    Tap("Connection Push 6", Con.Push("3456.Hobbies", "loo"), 2);
-    Tap("Connection Push 7", Con.Push("3456.Hobbies", "1", "2", "3"), 5);
+    tap("Connection Remove 1", con.remove("3456", F => F === "goo"), null);
+    tap("Connection Remove 2", con.remove("3456.hobbies", F => F === "foo"), 2);
+    tap("Connection Remove 3", con.remove("3456.hobbies", 5), 2);
+    tap("Connection Remove 4", con.remove("3456.hobbies", 1), 1);
 
-    Tap("Connection Shift 1", Con.Shift("3456.Hobbies"), "goo");
-    Tap("Connection Shift 2", Con.Shift("3456.Hobbies", "-5"), 5);
-    Tap("Connection Shift 3", Con.Shift("3456.Hobbies", "one", "two", "three"), 8);
+    tap("Connection Push 6", con.push("3456.hobbies", "loo"), 2);
+    tap("Connection Push 7", con.push("3456.hobbies", "1", "2", "3"), 5);
 
-    Tap("Connection Set 10", Con.Set("2345.Hobbies", ["one", "two", "three", "four"]).Fetch("2345.Hobbies.length"), 4);
+    tap("Connection Shift 1", con.shift("3456.hobbies"), "goo");
+    tap("Connection Shift 2", con.shift("3456.hobbies", "-5"), 5);
+    tap("Connection Shift 3", con.shift("3456.hobbies", "one", "two", "three"), 8);
 
-    Tap("Connection Slice 1", Con.Slice("3456.Hobbies"), 8);
-    Tap("Connection Slice 1", Con.Slice("3456.Hobbies", 1), 7);
-    Tap("Connection Slice 1", Con.Slice("3456.Hobbies", 0, 5), 5);
+    tap("Connection Set 10", con.set("2345.hobbies", ["one", "two", "three", "four"]).fetch("2345.hobbies.length"), 4);
+
+    tap("Connection Slice 1", con.slice("3456.hobbies"), 8);
+    tap("Connection Slice 1", con.slice("3456.hobbies", 1), 7);
+    tap("Connection Slice 1", con.slice("3456.hobbies", 0, 5), 5);
 
     // Utility methods
-    Tap("Connection Ensure 1", Con.Ensure("2345", {Name: "nope", Age: -1, Hobbies: []}), false);
-    Tap("Connection Ensure 2", Con.Ensure("6789", {Name: "Untitled", Age: -1, Hobbies: []}), true);
+    tap("Connection Ensure 1", con.ensure("2345", { name: "nope", age: -1, hobbies: [] }), false);
+    tap("Connection Ensure 2", con.ensure("6789", { name: "Untitled", age: -1, hobbies: [] }), true);
 
-    const Tr = Con.Transaction();
+    const tr = con.transaction();
 
-    Tap("Connection Modify 1", Con.Modify("6789.Name", Name => {
-        Name = "moo";
-        return Name;
-    }), {Name: "moo", Age: -1, Hobbies: []});
+    tap("Connection Modify 1", con.modify("6789.name", name => {
+        name = "moo";
+        return name;
+    }), {
+        name: "moo", age: -1, hobbies: []
+    });
 
-    Tap("Connection Modify 2", Con.Modify("6789.Hobbies", Hob => {
-        Hob.push({Programming: false});
-        return Hob;
-    }), {Name: "moo", Age: -1, Hobbies: [{Programming: false}]});
+    tap("Connection Modify 2", con.modify("6789.hobbies", hob => {
+        hob.push({ programming: false });
+        return hob;
+    }), {
+        name: "moo", age: -1, hobbies: [{ programming: false }]
+    });
 
-    Tap("Connection CacheSize 13", Con.CacheSize, 4);
+    tap("Connection CacheSize 13", con.cacheSize, 4);
 
-    Tr.Commit();
-    
-    Tap("Connection CacheSize 14", Con.CacheSize, 4);
-    Tap("Connection Fetch 7", Con.Fetch("6789"), {Name: "moo", Age: -1, Hobbies: [{Programming: false}]});
+    tr.commit();
 
-    Tap("Connection Invert 1", Con.Invert("6789.Hobbies.0.Programming"), true);
-    Tap("Connection Invert 2", Con.Invert("6789.Hobbies.0.Programming"), false);
-    Tap("Connection Invert 3", Con.Invert("6789.Hobbies.0.Programming"), true);
-    Tap("Connection Invert 4", Con.Invert("6789.Hobbies.0.Programming"), false);
+    tap("Connection CacheSize 14", con.cacheSize, 4);
+    tap("Connection Fetch 7", con.fetch("6789"), { name: "moo", age: -1, hobbies: [{ programming: false }]});
+
+    tap("Connection Invert 1", con.invert("6789.hobbies.0.programming"), true);
+    tap("Connection Invert 2", con.invert("6789.hobbies.0.programming"), false);
+    tap("Connection Invert 3", con.invert("6789.hobbies.0.programming"), true);
+    tap("Connection Invert 4", con.invert("6789.hobbies.0.programming"), false);
 
     // Transaction tests
-    const Tr2 = Con.Transaction();
+    const tr2 = con.transaction();
 
-    Tap("Connection Set 11", Con.Set("foo", {bar: "roo!"}).Size, 5);
-    Tap("Connection Fetch 8", Con.Fetch("foo"), {bar: "roo!"});
+    tap("Connection Set 11", con.set("foo", { bar: "roo!" }).size, 5);
+    tap("Connection Fetch 8", con.fetch("foo"), { bar: "roo!" });
 
-    Tap("Connection Size 15", Con.Size, 5);
-    Tap("Connection CacheSize 16", Con.CacheSize, 5);
+    tap("Connection Size 15", con.size, 5);
+    tap("Connection CacheSize 16", con.cacheSize, 5);
 
-    Tap("Connection Invert 5", Con.Invert("6789.Name"), false);
-    Tap("Connection Invert 6", Con.Fetch("6789.Name"), false);
+    tap("Connection Invert 5", con.invert("6789.name"), false);
+    tap("Connection Invert 6", con.fetch("6789.name"), false);
 
-    Tr2.Rollback();
+    tr2.rollback();
 
-    Tap("Connection Size 17", Con.Size, 4);
-    Tap("Connection CacheSize 17", Con.CacheSize, 0);
-    Tap("Connection Fetch 9", Con.Fetch("foo"), undefined);
-    Tap("Connection Invert 7", Con.Fetch("6789.Name"), "moo");
+    tap("Connection Size 17", con.size, 4);
+    tap("Connection CacheSize 17", con.cacheSize, 0);
+    tap("Connection Fetch 9", con.fetch("foo"), undefined);
+    tap("Connection Invert 7", con.fetch("6789.name"), "moo");
 
     // Iterator methods
-    let Results = [];
+    let results = [];
 
-    Con.Each((_Row, Key) => {
-        Results.push(Key);
+    con.each((_row, key) => {
+        results.push(key);
     }, true);
 
-    Tap("Connection Each", Results, ["4567", "2345", "3456", "6789"]);
+    tap("Connection Each", results, ["4567", "2345", "3456", "6789"]);
 
-    let Results2 = [];
+    let results2 = [];
 
-    for (const [Id, Document] of Con) {
-        Results2.push([Id, Document]);
+    for (const [id, documentObject] of con) {
+        results2.push([id, documentObject]);
     }
 
-    Tap("Connection Iterator", Results2, [
-        ["4567", {Name: "goo", Age: 27, Hobbies: []}],
-        ["2345", {Name: "bar", Age: 30, Hobbies: ["one", "two", "three", "four"]}],
-        ["3456", {Name: "roo", Age: 29, Hobbies: ["two", "three", "-5", "loo", "1"]}],
-        ["6789", {Name: "moo", Age: -1, Hobbies: [{Programming: false}]}],
+    tap("Connection Iterator", results2, [
+        ["4567", { name: "goo", age: 27, hobbies: [] }],
+        ["2345", { name: "bar", age: 30, hobbies: ["one", "two", "three", "four"] }],
+        ["3456", { name: "roo", age: 29, hobbies: ["two", "three", "-5", "loo", "1"] }],
+        ["6789", { name: "moo", age: -1, hobbies: [{ programming: false }] }],
     ]);
 
     // Selection class
-    Tap("Connection Select 1", Con.Select((_Row, Key) => {
-        return Key === "3456";
-    }).Holds, "QDB");
+    tap("Connection Select 1", con.select((_row, key) => {
+        return key === "3456";
+    }).holds, "QDB");
 
-    Tap("Connection Select 2", Con.Select().Cache.size, 4);
+    tap("Connection Select 2", con.select().cache.size, 4);
     
-    const Sel = Con.Select((_Row, Key) => Key.includes("4"));
-    Tap("Connection Select 3", Sel.Cache.size, 3);
+    const sel = con.select((_row, key) => key.includes("4"));
+    tap("Connection Select 3", sel.cache.size, 3);
 
-    Tap("Selection Keys 1", Sel.Keys, ["2345", "3456", "4567"]);
+    tap("Selection Keys 1", sel.keys, ["2345", "3456", "4567"]);
 
-    Tap("Selection Values 1", Sel.Values, [
-        {Name: "bar", Age: 30, Hobbies: ["one", "two", "three", "four"]},
-        {Name: "roo", Age: 29, Hobbies: ["two", "three", "-5", "loo", "1"]},
-        {Name: "goo", Age: 27, Hobbies: []}
+    tap("Selection Values 1", sel.values, [
+        { name: "bar", age: 30, hobbies: ["one", "two", "three", "four"] },
+        { name: "roo", age: 29, hobbies: ["two", "three", "-5", "loo", "1"] },
+        { name: "goo", age: 27, hobbies: [] }
     ]);
 
-    Tap("Selection AsObject 1", Sel.AsObject, {
-        "2345": {Name: "bar", Age: 30, Hobbies: ["one", "two", "three", "four"]},
-        "3456": {Name: "roo", Age: 29, Hobbies: ["two", "three", "-5", "loo", "1"]},
-        "4567": {Name: "goo", Age: 27, Hobbies: []}
+    tap("Selection AsObject 1", sel.asObject, {
+        "2345": { name: "bar", age: 30, hobbies: ["one", "two", "three", "four"] },
+        "3456": { name: "roo", age: 29, hobbies: ["two", "three", "-5", "loo", "1"] },
+        "4567": { name: "goo", age: 27, hobbies: [] }
     });
 
-    const Sel4 = Sel.Clone();
+    const sel4 = sel.clone();
 
-    Tap("Selection Order 1", Sel.Order((a, b) => a.Age - b.Age).Keys, ["4567", "3456", "2345"]);
-    Tap("Selection OrderBy 1", Sel.OrderBy(Item => Item.Age).Keys, ["2345", "3456", "4567"]);
-    Tap("Selection Filter 1", Sel.Filter((_Row, Key) => Key !== "3456").Cache.size, 2);
+    tap("Selection Order 1", sel.order((a, b) => a.age - b.age).keys, ["4567", "3456", "2345"]);
+    tap("Selection Filter 1", sel.filter((_row, key) => key !== "3456").cache.size, 2);
 
-    Tap("Selection Limit 1", Sel.Limit(0, 3).Cache.size, 2);
-    Tap("Selection Limit 2", Sel.Limit(1, 5).Cache.size, 1);
-    Tap("Selection Limit 3", Sel.Limit(1).Cache.size, 0);
+    tap("Selection Limit 1", sel.limit(0, 3).cache.size, 2);
+    tap("Selection Limit 2", sel.limit(1, 5).cache.size, 1);
+    tap("Selection Limit 3", sel.limit(1).cache.size, 0);
 
-    const Sel2 = Con.Select();
-    Tap("Selection Select 4", Sel2.Cache.size, 4);
-    
-    Sel2.Map((Val, Key) => {
-        Val = {...Val};
-        Val.foo = Key === "3456" ? "bar" : "roo";
-        return Val;
+    const sel2 = con.select();
+    tap("Selection Select 4", sel2.cache.size, 4);
+
+    sel2.map((val, key) => {
+        val = {...val};
+        val.foo = key === "3456" ? "bar" : "roo";
+        return val;
     });
 
-    Tap("Selection Map 1", Sel2.Cache.get("2345").foo, "roo");
-    Tap("Selection Map 2", Sel2.Cache.get("3456").foo, "bar");
-    Tap("Selection Map 3", Sel2.Cache.get("4567").foo, "roo");
-    Tap("Selection Map 4", Sel2.Cache.get("6789").foo, "roo");
+    tap("Selection Map 1", sel2.cache.get("2345").foo, "roo");
+    tap("Selection Map 2", sel2.cache.get("3456").foo, "bar");
+    tap("Selection Map 3", sel2.cache.get("4567").foo, "roo");
+    tap("Selection Map 4", sel2.cache.get("6789").foo, "roo");
 
-    Sel2.Group("foo");
+    sel2.group("foo");
 
-    Tap("Selection Group 1", Object.keys(Sel2.Cache.get("bar")).length, 1);
-    Tap("Selection Group 2", Object.keys(Sel2.Cache.get("roo")).length, 3);
+    tap("Selection Group 1", Object.keys(sel2.cache.get("bar")).length, 1);
+    tap("Selection Group 2", Object.keys(sel2.cache.get("roo")).length, 3);
 
-    const Sel3 = Sel2.Clone();
-    Sel3.Cache.set("boo", {Name: "boo", Age: 23, Hobbies: ["slep"]});
+    const sel3 = sel2.clone();
+    sel3.cache.set("boo", { name: "boo", age: 23, hobbies: ["slep"] });
 
-    Tap("Selection Clone 1", Sel3.Cache.size, 3);
-    Tap("Selection Clone 2", Sel2.Cache.size, 2);
+    tap("Selection Clone 1", sel3.cache.size, 3);
+    tap("Selection Clone 2", sel2.cache.size, 2);
 
     // Object reference tests
     const Selection = require("../lib/Utility/Selection");
 
-    const Projects = new Selection({
-        fooProj: {UserId: "4567", Does: ["nothing", "foo"]},
-        barProj: {UserId: "2345", Does: ["sleep"]},
-        rooProj: {UserId: "4567", Does: ["mind read"]},
-    }, "Projects");
+    const projects = new Selection({
+        fooProj: { userId: "4567", does: ["nothing", "foo"]},
+        barProj: { userId: "2345", does: ["sleep"]},
+        rooProj: { userId: "4567", does: ["mind read"]},
+    }, "projects");
 
-    const CopySel4 = Sel4.Clone();
-    Sel4.Join(Projects.Clone(), "UserId");
+    const copySel4 = sel4.clone();
+    sel4.join(projects.clone(), "userId");
 
-    Tap("Selection Join 1", Sel4.Cache.get("4567").Projects.fooProj.Does, ["nothing", "foo"]);
-    Tap("Selection Join 2", Sel4.Cache.get("2345").Projects.barProj.Does, ["sleep"]);
-    Tap("Selection Join 3", Sel4.Cache.get("4567").Projects.rooProj.Does, ["mind read"]);
+    tap("Selection Join 1", sel4.cache.get("4567").projects.fooProj.does, ["nothing", "foo"]);
+    tap("Selection Join 2", sel4.cache.get("2345").projects.barProj.does, ["sleep"]);
+    tap("Selection Join 3", sel4.cache.get("4567").projects.rooProj.does, ["mind read"]);
 
-    const CopyCloneSel4 = CopySel4.Clone();
-    const CopyCloneSel5 = CopySel4.Clone();
-    CopySel4.Join(Projects.Clone(), "UserId", "Customs");
+    const copyCloneSel4 = copySel4.clone();
+    const copyCloneSel5 = copySel4.clone();
+    copySel4.join(projects.clone(), "userId", "customs");
 
-    Tap("Selection Join 4", CopySel4.Cache.get("4567").Customs.fooProj.Does, ["nothing", "foo"]);
-    Tap("Selection Join 5", CopySel4.Cache.get("2345").Customs.barProj.Does, ["sleep"]);
-    Tap("Selection Join 6", CopySel4.Cache.get("4567").Customs.rooProj.Does, ["mind read"]);
+    tap("Selection Join 4", copySel4.cache.get("4567").customs.fooProj.does, ["nothing", "foo"]);
+    tap("Selection Join 5", copySel4.cache.get("2345").customs.barProj.does, ["sleep"]);
+    tap("Selection Join 6", copySel4.cache.get("4567").customs.rooProj.does, ["mind read"]);
 
-    CopyCloneSel4.Join(Projects.Clone(), "UserId", false);
+    copyCloneSel4.join(projects.clone(), "userId", false);
 
-    Tap("Selection Join 7", CopyCloneSel4.Cache.get("4567").fooProj.Does, ["nothing", "foo"]);
-    Tap("Selection Join 8", CopyCloneSel4.Cache.get("2345").barProj.Does, ["sleep"]);
-    Tap("Selection Join 9", CopyCloneSel4.Cache.get("4567").rooProj.Does, ["mind read"]);
+    tap("Selection Join 7", copyCloneSel4.cache.get("4567").fooProj.does, ["nothing", "foo"]);
+    tap("Selection Join 8", copyCloneSel4.cache.get("2345").barProj.does, ["sleep"]);
+    tap("Selection Join 9", copyCloneSel4.cache.get("4567").rooProj.does, ["mind read"]);
 
-    CopyCloneSel5.Join(Projects.Clone().Map(Item => {
-        Item.Example = {UserId: Item.UserId};
-        return Item;
-    }), "Example.UserId");
+    copyCloneSel5.join(projects.clone().map(item => {
+        item.example = { userId: item.userId };
+        return item;
+    }), "example.userId");
 
-    Tap("Selection Join 10", CopyCloneSel5.Cache.get("4567").Projects.fooProj.Does, ["nothing", "foo"]);
-    Tap("Selection Join 11", CopyCloneSel5.Cache.get("2345").Projects.barProj.Does, ["sleep"]);
-    Tap("Selection Join 12", CopyCloneSel5.Cache.get("4567").Projects.rooProj.Does, ["mind read"]);
+    tap("Selection Join 10", copyCloneSel5.cache.get("4567").projects.fooProj.does, ["nothing", "foo"]);
+    tap("Selection Join 11", copyCloneSel5.cache.get("2345").projects.barProj.does, ["sleep"]);
+    tap("Selection Join 12", copyCloneSel5.cache.get("4567").projects.rooProj.does, ["mind read"]);
 
-    Sel.Merge(Sel3, Sel4);
+    sel.merge(sel3, sel4);
 
-    Tap("Selection Merge 1", Sel.Cache.size, 6);
-    Tap("Selection Merge 2", Sel3.Cache.size, 3);
-    Tap("Selection Merge 3", Sel4.Cache.size, 3);
+    tap("Selection Merge 1", sel.cache.size, 6);
+    tap("Selection Merge 2", sel3.cache.size, 3);
+    tap("Selection Merge 3", sel4.cache.size, 3);
 
-    Tap("Selection Merge 4", Sel.Keys, [
+    tap("Selection Merge 4", sel.keys, [
         "roo", "bar", "boo",
         "2345", "3456", "4567"
     ]);
 
-    Tap("Selection Retrieve 1", Sel.Retrieve("bar"), {
-        "3456": {Name: "roo", Age: 29, Hobbies: ["two", "three", "-5", "loo", "1"], foo: "bar"}
+    tap("Selection Retrieve 1", sel.retrieve("bar"), {
+        "3456": { name: "roo", age: 29, hobbies: ["two", "three", "-5", "loo", "1"], foo: "bar" }
     });
 
-    Tap("Selection Retrieve 2", Sel.Retrieve("bar.Age"), undefined);
-    Tap("Selection Retrieve 3", Sel.Retrieve("bar.3456.Age"), 29);
-    Tap("Selection Retrieve 4", Sel.Retrieve("bar.3456.Hobbies.length"), 5);
+    tap("Selection Retrieve 2", sel.retrieve("bar.age"), undefined);
+    tap("Selection Retrieve 3", sel.retrieve("bar.3456.age"), 29);
+    tap("Selection Retrieve 4", sel.retrieve("bar.3456.hobbies.length"), 5);
 
-    Con.Disconnect();
+    con.disconnect();
 
     // Pool class
-    const Pl = new QDB.Pool("Test/");
+    const pl = new QDB.Pool("Test/");
 
-    Tap("Pool Size 1", Pl.Store.size, 1);
+    tap("Pool Size 1", pl.store.size, 1);
 
-    Tap("Pool Select 1", Pl.Select("Users"), Pl.Store.first());
-    Tap("Pool Select 2", Pl.Select("Guilds"), undefined);
-    Tap("Pool Select 3", Pl.Select("QDB"), undefined);
+    tap("Pool Select 1", pl.select("Users"), pl.store.first());
+    tap("Pool Select 2", pl.select("Guilds"), undefined);
+    tap("Pool Select 3", pl.select("QDB"), undefined);
 
-    Tap("Pool Connection", Pl.Select("Users").Size, 4);
+    tap("Pool Connection", pl.select("Users").size, 4);
 
-    Pl.Disconnect();
+    pl.disconnect();
 
-    Tap("Pool Disconnect", Pl.Store.size, 0);
+    tap("Pool Disconnect", pl.store.size, 0);
 
     // Executors
-    const ECon = new QDB.Connection("Test/Users.qdb", {
-        FetchAll: true,
-        CacheMaxSize: 2
+    const eCon = new QDB.Connection("Test/Users.qdb", {
+        fetchAll: true,
+        cacheMaxSize: 2
     });
 
-    Tap("Connection Size 16", ECon.Size, 4);
-    Tap("Connection CacheSize 18", ECon.CacheSize, 2);
+    tap("Connection Size 16", eCon.size, 4);
+    tap("Connection CacheSize 18", eCon.cacheSize, 2);
 
-    ECon.Disconnect();
-
+    eCon.disconnect();
 }

--- a/lib/Connections/Backups/Manager.js
+++ b/lib/Connections/Backups/Manager.js
@@ -11,53 +11,52 @@ class BackupManager {
 
     /**
      * A utility class for creating backups of databases.
-     * @param {Pathlike} PathURL Path to the database file or directory to backup.
-     * @param {BackupOptions} BackupOptions Options to use for this Backup Manager.
-     * @example new QDB.BackupManager("lib/Databases/", { Destination: "/usr/local/backups/" });
+     * @param {Pathlike} pathURL Path to the database file or directory to backup.
+     * @param {BackupOptions} backupOptions Options to use for this Backup Manager.
+     * @example new QDB.BackupManager("../Cellar/", { destination: "/usr/local/backups/" });
      * @extends {EventEmitter}
      */
-    constructor (PathURL, BackupOptions = {}) {
-
-        if (FS.existsSync(PathURL)) {
+    constructor (pathURL, backupOptions = {}) {
+        if (FS.existsSync(pathURL)) {
 
             /**
              * Path string to a directory or database file.
-             * @name BackupManager#Path
+             * @name BackupManager#path
              * @type {Pathlike}
              * @readonly
              */
-            Object.defineProperty(this, "Path", {
+            Object.defineProperty(this, "path", {
                 enumerable: true,
-                value: PathURL
+                value: pathURL
             });
 
             /**
              * Options for this Manager.
-             * @name BackupManager#ValOptions
+             * @name BackupManager#valOptions
              * @type {BackupOptions}
              * @private
              */
-            Object.defineProperty(this, "ValOptions", {
+            Object.defineProperty(this, "valOptions", {
                 value: {
-                    Retry: true,
+                    retry: true,
 
-                    Destination: "Backups/",
-                    Interval:    3600000,
-                    Snapshots:   24,
+                    destination: "Backups/",
+                    interval:    3600000,
+                    snapshots:   24,
 
-                    ...BackupOptions
+                    ...backupOptions
                 }
             });
 
             /**
              * Path string to the destination of the backups.
-             * @name BackupManager#Destination
+             * @name BackupManager#destination
              * @type {Pathlike}
              * @readonly
              */
-            Object.defineProperty(this, "Destination", {
+            Object.defineProperty(this, "destination", {
                 enumerable: true,
-                value: this.ValOptions.Destination
+                value: this.valOptions.destination
             });
 
         } else {
@@ -67,11 +66,11 @@ class BackupManager {
 
         /**
          * The child process that manages the backups.
-         * @name BackupManager#_Process
+         * @name BackupManager#_process
          * @type {Process?}
          * @private
          */
-        Object.defineProperty(this, "_Process", {
+        Object.defineProperty(this, "_process", {
             writable: true,
             value: null
         });
@@ -79,27 +78,26 @@ class BackupManager {
         /**
          * This manager's event manager to control
          * the information of the backup child process.
-         * @name BackupManager#_EventEmitter
+         * @name BackupManager#_eventEmitter
          * @type {EventEmitter}
          * @private
          */
-        Object.defineProperty(this, "_EventEmitter", {
+        Object.defineProperty(this, "_eventEmitter", {
             value: new Events()
         });
 
         this.Spawn();
-
     }
 
 
     /**
      * Registers an event listener on one of this Manager's events.
-     * @param {String} Event Which action to register for the listener.
-     * @param {Function} Listener Function to execute upon this event.
+     * @param {String} event Which action to register for the listener.
+     * @param {Function} listener Function to execute upon this event.
      * @returns {BackupManager}
      */
-    On (Event, Listener) {
-        this._EventEmitter.on(Event, Listener);
+    on (event, listener) {
+        this._eventEmitter.on(event, listener);
         return this;
     }
 
@@ -107,39 +105,38 @@ class BackupManager {
      * Spawns the child process for this Manager.
      * @returns {BackupManager}
      */
-    Spawn () {
-        if (this._Process) throw new Error("Backup process exists for this Manager.");
+    spawn () {
+        if (this._process) throw new Error("Backup process exists for this Manager.");
 
-        this._Process = Child.fork(Path.join(__dirname, "Process.js"), {
-            env: {PathURL: this.Path, ...this.ValOptions}
+        this._process = Child.fork(Path.join(__dirname, "Process.js"), {
+            env: { pathURL: this.path, ...this.valOptions }
         });
 
-        this._Process
-        .on("exit",    C => this._EventEmitter.emit("Exit", C))
-        .on("error",   E => this._EventEmitter.emit("Error", E))
-        .on("message", M => this._EventEmitter.emit("Debug", M));
+        this._process
+            .on("exit",    C => this._eventEmitter.emit("exit", C))
+            .on("error",   E => this._eventEmitter.emit("error", E))
+            .on("message", M => this._eventEmitter.emit("debug", M));
 
-        this._Process.on("exit", C => {
-            this._Process.removeAllListeners();
-            this._Process = null;
-            if (this.ValOptions.Retry && C && C !== 0) this.Spawn();
+        this._process.on("exit", C => {
+            this._process.removeAllListeners();
+            this._process = null;
+            if (this.valOptions.retry && C && C !== 0) this.spawn();
         });
 
-        setImmediate(() => this._EventEmitter.emit("Spawn", this._Process.pid));
+        setImmediate(() => this._eventEmitter.emit("spawn", this._process.pid));
 
         return this;
     }
 
     /**
-     * Ends the backup process and emits the `Exit` event.
+     * Ends the backup process and emits the `exit` event.
      * @returns {BackupManager}
      */
-    Exit () {
-        if (!this._Process) throw new Error("Backup process isn't running.");
-        this._Process.kill("SIGTERM");
+    exit () {
+        if (!this._process) throw new Error("Backup process isn't running.");
+        this._process.kill("SIGTERM");
         return this;
     }
-
 }
 
 module.exports = BackupManager;
@@ -150,19 +147,19 @@ module.exports = BackupManager;
  * All integer related options are in milliseconds.
  * @typedef {Object} BackupOptions
 
- * @param {Boolean} Retry Whether or not to retry spawning this Manager's child process if it exits with a non-zero code.
+ * @param {Boolean} retry Whether or not to retry spawning this Manager's child process if it exits with a non-zero code.
 
- * @param {String} Destination Path to the directory where backups will be placed in.
- * @param {Number} Interval A time interval for when copies of the database(s) will be created.
- * @param {Number} Snapshots Maximum amount of snapshots to create until making a full backup.
+ * @param {String} destination Path to the directory where backups will be placed in.
+ * @param {Number} interval A time interval for when copies of the database(s) will be created.
+ * @param {Number} snapshots Maximum amount of snapshots to create until making a full backup.
  */
 
 /**
- * Events related to the BackupManager, registered by `Manager.On(...);`.
+ * Events related to the BackupManager, registered by `manager.on(...);`.
  * @typedef {Events} BackupEvents
 
- * @param {Timestamp} Spawn Fired upon a new child process being created for this Manager.
- * @param {Number} Exit Executed with the status code as argument of the function.
- * @param {Error} Error Fired when the child process encountered an error.
- * @param {String} Debug Any message from the backup process with information about its state.
+ * @param {Timestamp} spawn Fired upon a new child process being created for this Manager.
+ * @param {Number} exit Executed with the status code as argument of the function.
+ * @param {Error} error Fired when the child process encountered an error.
+ * @param {String} debug Any message from the backup process with information about its state.
  */

--- a/lib/Connections/Backups/Process.js
+++ b/lib/Connections/Backups/Process.js
@@ -5,49 +5,52 @@ const FS   = require("fs");
 const Path = require("path");
 
 const {
-    PathURL, Destination, Interval, Snapshots
+    pathURL, destination, interval, snapshots
 } = process.env;
 
-let SnapshotIdx = 0;
+let snapshotIdx = 0;
 
 
-function Backup (ResolvedPath, IsDirectory) {
-    const EndpointPath = Path.join(ResolvedPath, new Date().toISOString());
+function backup (resolvedPath, isDirectory) {
+    const endpointPath = Path.join(resolvedPath, new Date().toISOString());
 
-    if (IsDirectory) {
-        FS.mkdirSync(EndpointPath);
-        FS.readdirSync(PathURL).forEach(Database => {
-            const Source = Path.join(PathURL, Database);
-            const Destination = Path.join(EndpointPath, Database);
-            FS.copyFile(Source, Destination, () => {});
+    if (isDirectory) {
+        FS.mkdirSync(endpointPath);
+        FS.readdirSync(pathURL).forEach(database => {
+            const source = Path.join(pathURL, database);
+            const destination = Path.join(endpointPath, database);
+            FS.copyFile(source, destination, () => {});
         });
     } else {
-        const Destination = `${EndpointPath}.qdb`;
-        FS.copyFile(PathURL, Destination, () => {});
+        const destination = `${endpointPath}.qdb`;
+        FS.copyFile(pathURL, destination, () => {});
     }
 
-    return EndpointPath;
+    return endpointPath;
 }
 
-function Pathfinder () {
+function pathfinder () {
+    const databaseHostName = pathURL
+        .split("/")
+        .filter(A => !!A)
+        .pop()
+        .split(".")[0];
 
-    const DatabaseHostName = PathURL.split("/")
-    .filter(A => !!A).pop().split(".")[0];
+    const isDirectory        = FS.lstatSync(pathURL).isDirectory();
+    const middleware         = snapshotIdx < snapshots ? "Snapshots" : "";
+    const resolvedBackupPath = Path.resolve(destination, middleware, databaseHostName);
 
-    const IsDirectory        = FS.lstatSync(PathURL).isDirectory();
-    const Middleware         = SnapshotIdx < Snapshots ? "Snapshots" : "";
-    const ResolvedBackupPath = Path.resolve(Destination, Middleware, DatabaseHostName);
+    snapshotIdx = snapshotIdx < snapshots ?
+        (snapshotIdx + 1) :
+        0;
 
-    SnapshotIdx = SnapshotIdx < Snapshots ? (SnapshotIdx + 1) : 0;
-
-    if (!FS.existsSync(ResolvedBackupPath))
-    FS.mkdir(ResolvedBackupPath, {recursive: true}, () => Backup(ResolvedBackupPath, IsDirectory));
-    else Backup(ResolvedBackupPath, IsDirectory);
-
+    !FS.existsSync(resolvedBackupPath) ?
+        FS.mkdir(resolvedBackupPath, { recursive: true }, () => backup(resolvedBackupPath, isDirectory)) :
+        backup(resolvedBackupPath, isDirectory);
 }
 
 setInterval(() => {
-    if (!FS.existsSync(Destination))
-    FS.mkdir(Destination, {recursive: true}, Pathfinder);
-    else Pathfinder();
-}, Interval);
+    !FS.existsSync(destination) ?
+        FS.mkdir(destination, { recursive: true }, pathfinder) :
+        pathfinder();
+}, interval);

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -13,7 +13,7 @@ class Connection {
      * @param {Pathlike} pathURL Path to the database file of this Connection.
      * @param {RawOptions} [rawOptions] Options for this Connection.
      * @param {Pool} [_poolController] Reference to a Pool if this database was instantiated in a Pool.
-     * @example const Users = new QDB.Connection("lib/Databases/Users.qdb");
+     * @example const users = new QDB.Connection("../Cellar/Users.qdb");
      */
     constructor (pathURL, rawOptions = {}, _poolController = undefined) {
 
@@ -94,7 +94,7 @@ class Connection {
          * @private
          */
         Object.defineProperty(this, "API", {
-            value: new SQL(PathURL, {
+            value: new SQL(pathURL, {
                 verbose: rawOptions.queries
             })
         });
@@ -182,7 +182,7 @@ class Connection {
      * or want to fully disconnect from this database.
      * @returns {Connection}
      */
-    Disconnect () {
+    disconnect () {
         this.API.close();
         this.memory.clear();
         this.state = "DISCONNECTED";
@@ -357,14 +357,14 @@ class Connection {
      * @param {Boolean} [cache] Whether to, if not already, cache this entry in results that the next retrieval would be much faster.
      * @returns {Object|Array|DataModel|*} Value of the row, or the property when using dotaccess.
      */
-    Fetch (keyOrPath, cache = this.valOptions.cache) {
+    fetch (keyOrPath, cache = this.valOptions.cache) {
         if (!this._ready) return null;
         if (typeof keyOrPath !== "string") return null;
 
-        const [key, path] = this._Resolve(keyOrPath);
+        const [key, path] = this._resolve(keyOrPath);
 
         let fetched = this.memory.get(key) || (() => {
-            const document = this.API.prepare(`SELECT Val FROM '${this.table}' WHERE Key = ?;`).get(Key);
+            const document = this.API.prepare(`SELECT Val FROM '${this.table}' WHERE Key = ?;`).get(key);
             if (typeof document !== "undefined") return JSON.parse(document.Val);
             return document;
         })();
@@ -448,7 +448,7 @@ class Connection {
         if (!this._ready) return null;
         if (typeof method !== "function") return null;
 
-        const rows = this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).all();
+        const rows = this.API.prepare(`SELECT Key, Val FROM '${this.table}';`).all();
         for (const entry of rows) method(JSON.parse(entry.Val), entry.Key);
 
         return this;
@@ -474,7 +474,7 @@ class Connection {
 
         for (const entry of iterableRows) {
             const column = JSON.parse(entry.Val);
-            if (Fn(column, entry.Key)) return column;
+            if (predicate(column, entry.Key)) return column;
         }
 
         return undefined;
@@ -491,7 +491,7 @@ class Connection {
 
         const entries = typeof predicateOrPath === "string" ? this.fetch(predicateOrPath) : (() => {
             if (typeof predicateOrPath !== "function") return {};
-            const rows = this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).all();
+            const rows = this.API.prepare(`SELECT Key, Val FROM '${this.table}';`).all();
             const results = {};
 
             for (const entry of rows) {

--- a/lib/Connections/Connection.js
+++ b/lib/Connections/Connection.js
@@ -1,7 +1,7 @@
 
 "use strict";
 
-const {Schema} = require("../Utility/Schema");
+const { Schema } = require("../Utility/Schema");
 
 const Qulity = require("qulity");
 const SQL    = require("better-sqlite3");
@@ -10,20 +10,20 @@ class Connection {
 
     /**
      * The main interface for interacting with QDB.
-     * @param {Pathlike} PathURL Path to the database file of this Connection.
-     * @param {RawOptions} [RawOptions] Options for this Connection.
-     * @param {Pool} [_Pool] Reference to a Pool if this database was instantiated in a Pool.
+     * @param {Pathlike} pathURL Path to the database file of this Connection.
+     * @param {RawOptions} [rawOptions] Options for this Connection.
+     * @param {Pool} [_poolController] Reference to a Pool if this database was instantiated in a Pool.
      * @example const Users = new QDB.Connection("lib/Databases/Users.qdb");
      */
-    constructor (PathURL, RawOptions = {}, _Pool = undefined) {
+    constructor (pathURL, rawOptions = {}, _poolController = undefined) {
 
         /**
          * Current state of this Connection.
-         * @name Connection#State
+         * @name Connection#state
          * @type {String}
          * @readonly
          */
-        Object.defineProperty(this, "State", {
+        Object.defineProperty(this, "state", {
             enumerable: true,
             writable:   true,
             value:      "CONNECTED"
@@ -31,59 +31,59 @@ class Connection {
 
         /**
          * Path string to the database.
-         * @name Connection#Path
+         * @name Connection#path
          * @type {Pathlike}
          * @readonly
          */
-        Object.defineProperty(this, "Path", {
+        Object.defineProperty(this, "path", {
             enumerable: true,
-            value: PathURL
+            value: pathURL
         });
 
         /**
          * Options for this Connection.
-         * @name Connection#ValOptions
+         * @name Connection#valOptions
          * @type {RawOptions}
          * @readonly
          */
-        Object.defineProperty(this, "ValOptions", {
+        Object.defineProperty(this, "valOptions", {
             value: {
-                Table:  "QDB",
-                Schema: undefined,
+                table:  "QDB",
+                schema: undefined,
                 WAL:    true,
 
-                Cache:     true,
-                FetchAll:  false,
-                UtilCache: true,
+                cache:     true,
+                fetchAll:  false,
+                utilCache: true,
 
-                CacheMaxSize:  false,
-                SweepInterval: 300000,
-                SweepLifetime: 150000,
+                cacheMaxSize:  false,
+                sweepInterval: 300000,
+                sweepLifetime: 150000,
 
-                ...RawOptions
+                ...rawOptions
             }
         });
 
         /**
          * Reference to the Pool this Connection was created in.
-         * @name Connection#Pool
+         * @name Connection#poolController
          * @type {Pool?}
          * @readonly
          */
-        Object.defineProperty(this, "Pool", {
+        Object.defineProperty(this, "poolController", {
             enumerable: true,
-            value: _Pool || null
+            value: _poolController || null
         });
 
         /**
          * Table name of this Connection.
-         * @name Connection#Table
+         * @name Connection#table
          * @type {String}
          * @readonly
          */
-        Object.defineProperty(this, "Table", {
+        Object.defineProperty(this, "table", {
             enumerable: true,
-            value: this.ValOptions.Table || "QDB"
+            value: this.valOptions.table || "QDB"
         });
 
         /**
@@ -95,18 +95,18 @@ class Connection {
          */
         Object.defineProperty(this, "API", {
             value: new SQL(PathURL, {
-                verbose: RawOptions.Queries
+                verbose: rawOptions.queries
             })
         });
 
         /**
          * In-memory cached rows.
-         * @name Connection#Cache
+         * @name Connection#memory
          * @type {Collection}
          * @link https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md
          * @private
          */
-        Object.defineProperty(this, "Cache", {
+        Object.defineProperty(this, "memory", {
             value: new Qulity.Collection()
         });
 
@@ -114,8 +114,8 @@ class Connection {
         if (!this.API) {
             throw new Error("A QDB Connection could not be created.");
         } else {
-            this.API.prepare(`CREATE TABLE IF NOT EXISTS '${this.Table}' ('Key' VARCHAR PRIMARY KEY, 'Val' TEXT);`).run();
-            this.API.pragma(`journal_mode = ${this.ValOptions.WAL ? "wal" : "delete"};`);
+            this.API.prepare(`CREATE TABLE IF NOT EXISTS '${this.table}' ('Key' VARCHAR PRIMARY KEY, 'Val' TEXT);`).run();
+            this.API.pragma(`journal_mode = ${this.valOptions.WAL ? "wal" : "delete"};`);
             this.API.pragma("cache_size = 64000;");
             this.API.pragma("synchronous = 1;");
         }
@@ -124,49 +124,56 @@ class Connection {
         /**
          * An object with all additional active operators.
          * I.e. sweep intervals, backups, fetch all entries.
-         * @name Connection#_Executors
+         * @name Connection#_executors
          * @type {Object}
          * @private
          */
-        const Executors = require("./Executors/Index");
-        Object.defineProperty(this, "_Executors", {value: {}});
-        for (const Method in Executors) if (this.ValOptions[Method])
-        this._Executors[Method] = Executors[Method](this);
+        Object.defineProperty(this, "_executors", {
+            value: {}
+        });
 
+        const executors = require("./Executors/Index");
+        for (const method in executors) {
+            if (this.valOptions[method])
+                this._executors[method] = executors[method](this);
+        }
     }
 
 
     /**
      * Retrieves all the rows of this Connection.
-     * @name Connection#Size
+     * @name Connection#size
      * @type {Number}
      */
-    get Size () {
-        if (!this._Ready) return 0;
-        return this.API.prepare(`SELECT COUNT(*) FROM '${this.Table}';`)
-        .get()["COUNT(*)"];
+    get size () {
+        if (!this._ready) return 0;
+        return this.API
+            .prepare(`SELECT COUNT(*) FROM '${this.table}';`)
+            .get()["COUNT(*)"];
     }
 
     /**
      * Retrieves all the in-memory cached rows of this Connection.
-     * Extension of what would be `<Connection>.Cache.size`, but checks for the ready state.
-     * @name Connection#CacheSize
+     * Extension of what would be `<Connection>.memory.size`, but checks for the ready state.
+     * @name Connection#cacheSize
      * @type {Number}
      */
-    get CacheSize () {
-        if (!this._Ready) return 0;
-        return this.Cache.size;
+    get cacheSize () {
+        if (!this._ready) return 0;
+        return this.memory.size;
     }
 
     /**
      * Retrieves all the keys of this database table.
-     * @name Connection#Indexes
+     * @name Connection#indexes
      * @type {Array}
      */
-    get Indexes () {
-        if (!this._Ready) return [];
-        return this.API.prepare(`SELECT Key FROM '${this.Table}';`)
-        .all().map(Row => Row.Key);
+    get indexes () {
+        if (!this._ready) return [];
+        return this.API
+            .prepare(`SELECT Key FROM '${this.table}';`)
+            .all()
+            .map(row => row.Key);
     }
 
     /**
@@ -177,10 +184,10 @@ class Connection {
      */
     Disconnect () {
         this.API.close();
-        this.Cache.clear();
-        this.State = "DISCONNECTED";
+        this.memory.clear();
+        this.state = "DISCONNECTED";
 
-        clearInterval(this._Executors.SweepInterval);
+        clearInterval(this._executors.sweepInterval);
 
         return this;
     }
@@ -191,75 +198,75 @@ class Connection {
     /**
      * Internal getter.
      * Checks whether this database is ready for execution.
-     * @name Connection#_Ready
+     * @name Connection#_ready
      * @type {Boolean}
      * @private
      */
-    get _Ready () {
-        return this.State === "CONNECTED" && this.API.open;
+    get _ready () {
+        return this.state === "CONNECTED" && this.API.open;
     }
 
     /**
      * Internal method.
      * Resolves a dotaccess path or key and parses it.
-     * @param {Pathlike} Pathlike String input to be formed and parsed.
-     * @returns {Array<String, Array?>} Array containnig a 'Key' and an optional 'Path'.
+     * @param {Pathlike} pathlike String input to be formed and parsed.
+     * @returns {Array<String, Array?>} Array containnig a 'key' and an optional 'path'.
      * @private
      */
-    _Resolve (Pathlike) {
-        const Path = Pathlike.split(/\.+/g);
-        return [Path[0], Path.length > 1 ? Path.slice(1) : undefined];
+    _resolve (pathlike) {
+        const path = pathlike.split(/\.+/g);
+        return [path[0], path.length > 1 ? path.slice(1) : undefined];
     }
 
     /**
      * Internal method.
      * Inserts or patches something in this Connection's internal cache.
-     * @param {String|Number} Key As address to memory map this value to.
-     * @param {Object|Array} Val The value to set in the memory cache.
+     * @param {String|Number} key As address to memory map this value to.
+     * @param {Object|Array} document The value to set in the memory cache.
      * @returns {Collection} Returns the updated cache instance of this Connection.
      * @link https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md
      * @private 
      */
-    _Patch (Key, Val) {
-        if (this.ValOptions.CacheMaxSize &&
-            this.Cache.size >= this.ValOptions.CacheMaxSize &&
-            !this.Cache.has(Key)) return this.Cache;
+    _patch (key, document) {
+        if (this.valOptions.cacheMaxSize &&
+            this.memory.size >= this.valOptions.cacheMaxSize &&
+            !this.memory.has(key)) return this.memory;
 
-        const Value = Val instanceof Array ? [...Val] : {...Val};
-        Value._Timestamp = Date.now();
-        this.Cache.set(Key, Value);
-    
-        return this.Cache;
+        const value = document instanceof Array ? [...document] : {...document};
+        value._timestamp = Date.now();
+        this.memory.set(key, value);
+
+        return this.memory;
     }
 
     /**
      * Internal method.
      * Finds a relative dotaccess pathway of an object.
-     * @param {Object|Array} Frame The object-like beginning to cast.
-     * @param {Array} Pathlike A dotaccess notation path as an Array. Preferred `Path` value from `_Resolve()`.
-     * @param {*} [Item] A value to cast into the inputted frame object.
+     * @param {Object|Array} frame The object-like beginning to cast.
+     * @param {Array} pathlike A dotaccess notation path as an Array. Preferred `Path` value from `_Resolve()`.
+     * @param {*} [item] A value to cast into the inputted frame object.
      * @returns {*} Returns the output of the caster.
      * @private
      */
-    _CastPath (Frame, Pathlike, Item = undefined) {
-        const Original = Frame;
-        const KeyLast  = Pathlike.pop();
+    _castPath (frame, pathlike, item = undefined) {
+        const originalObject = frame;
+        const lastFrameKey = pathlike.pop();
 
-        for (const Key of Pathlike) {
-            if (typeof Frame !== "object") return;
+        for (const key of pathlike) {
+            if (typeof frame !== "object") return;
 
-            if (!(Key in Frame)) {
-                if (!Item) return;
-                Frame[Key] = {};
+            if (!(key in frame)) {
+                if (!item) return;
+                frame[key] = {};
             }
 
-            Frame = Frame[Key];
+            frame = frame[key];
         }
 
-        if (Frame) {
-            if (Item === undefined) return Frame[KeyLast];
-            Frame[KeyLast] = Item;
-            return Original;
+        if (frame) {
+            if (item === undefined) return frame[lastFrameKey];
+            frame[lastFrameKey] = item;
+            return originalObject;
         }
     }
 
@@ -267,42 +274,51 @@ class Connection {
     // ---------------------------------------------------------------- Integrations
 
     * [Symbol.iterator] () {
-        const Items = this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).all();
-        yield* Items.map(Row => [Row.Key, JSON.parse(Row.Val)]);
+        const items = this.API
+            .prepare(`SELECT Key, Val FROM '${this.table}';`)
+            .all();
+        yield* items.map(row => [row.Key, JSON.parse(row.Val)]);
     }
 
     /**
-     * Converts this database's rows into an Object. To use dotaccess, use `Fetch` instead.
+     * Converts this database's rows into an Object. To use dotaccess, use `fetch` instead.
      * @returns {Object} An object instance with the key/value pairs of this database.
      */
-    AsObject () {
-        if (!this._Ready) return null;
-        return Object.fromEntries(this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`)
-        .all().map(Row => [Row.Key, JSON.parse(Row.Val)]));
+    asObject () {
+        if (!this._ready) return null;
+        const enumeratedEntries = this.API
+            .prepare(`SELECT Key, Val FROM '${this.table}';`)
+            .all()
+            .map(row => [row.Key, JSON.parse(row.Val)]);
+        return Object.fromEntries(enumeratedEntries);
     }
 
     /**
      * Converts this database, or a part of it using dotaccess, to a Manager instance.
-     * @param {Pathlike} [Pathlike] Optional dotaccess path pointing towards what to serialise.
-     * @param {Function} [Holds] Given optional class for which instance this Manager is for.
+     * @param {Pathlike} [pathlike] Optional dotaccess path pointing towards what to serialise.
+     * @param {Function} [holds] Given optional class for which instance this Manager is for.
      * @returns {Manager} A Manager instance with the key/model pairs.
      * @link https://github.com/QSmally/Qulity/blob/master/Documentation/BaseManager.md
      */
-    ToIntegratedManager (Pathlike = null, Holds = null) {
-        if (!this._Ready) return null;
-        
-        if (Pathlike && typeof Pathlike !== "string") return null;
-        const Iterable = typeof Pathlike !== "undefined" ? this.Fetch(Pathlike) :
-        this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).all().map(Row => [Row.Key, JSON.parse(Row.Val)]);
+    toIntegratedManager (pathlike = null, holds = null) {
+        if (!this._ready) return null;
+        if (pathlike && typeof pathlike !== "string") return null;
 
-        return new Qulity.Manager(Iterable, Holds);
+        const iterable = typeof pathlike === "undefined" ?
+            this.fetch(pathlike) :
+            this.API
+                .prepare(`SELECT Key, Val FROM '${this.table}';`)
+                .all()
+                .map(row => [row.Key, JSON.parse(row.Val)]);
+
+        return new Qulity.Manager(iterable, holds);
     }
 
     /**
      * Creates a SQL transaction, which allows you to commit or rollback changes.
      * @returns {Transaction?} A Transaction instance, or a nil value when already in a transaction.
      */
-    Transaction () {
+    transaction () {
         if (this.API.inTransaction) return;
         const Transaction = require("../Utility/Transaction");
         return new Transaction(this);
@@ -313,89 +329,93 @@ class Connection {
 
     /**
      * Manages the elements of the database.
-     * @param {Pathlike} KeyOrPath Specifies at what row to insert or replace the element at. Use dotaccess notation to edit properties.
-     * @param {Object|Array|DataModel|*} Value Data to set at the row address, at the location of the key or path.
+     * @param {Pathlike} keyOrPath Specifies at what row to insert or replace the element at. Use dotaccess notation to edit properties.
+     * @param {Object|Array|DataModel|*} document Data to set at the row address, at the location of the key or path.
      * @returns {Connection} Returns the current Connection.
      */
-    Set (KeyOrPath, Value) {
-        if (!this._Ready)                  return null;
-        if (typeof KeyOrPath !== "string") return null;
-        if (Value === undefined)           return null;
+    set (keyOrPath, document) {
+        if (!this._ready)                  return null;
+        if (typeof keyOrPath !== "string") return null;
+        if (document === undefined)        return null;
 
-        const [Key, Path] = this._Resolve(KeyOrPath);
-        
-        if (typeof Path !== "undefined") Value = this._CastPath(this.Fetch(Key) || {}, Path, Value);
-        else if (typeof Value !== "object") return null;
-        
-        if (this.Cache.has(Key)) this._Patch(Key, Value);
-        this.API.prepare(`INSERT OR REPLACE INTO '${this.Table}' ('Key', 'Val') VALUES (?, ?);`)
-        .run(Key, JSON.stringify(Value));
+        const [key, path] = this._resolve(keyOrPath);
+
+        if (typeof path !== "undefined") document = this._castPath(this.fetch(key) || {}, path, document);
+        else if (typeof document !== "object") return null;
+        if (this.memory.has(key)) this._patch(key, document);
+
+        this.API
+            .prepare(`INSERT OR REPLACE INTO '${this.table}' ('Key', 'Val') VALUES (?, ?);`)
+            .run(key, JSON.stringify(document));
 
         return this;
     }
 
     /**
      * Manages the retrieval of the database.
-     * @param {Pathlike} KeyOrPath Specifies which row to fetch or get from cache. Use dotaccess to retrieve properties.
-     * @param {Boolean} [Cache] Whether to, if not already, cache this entry in results that the next retrieval would be much faster.
+     * @param {Pathlike} keyOrPath Specifies which row to fetch or get from cache. Use dotaccess to retrieve properties.
+     * @param {Boolean} [cache] Whether to, if not already, cache this entry in results that the next retrieval would be much faster.
      * @returns {Object|Array|DataModel|*} Value of the row, or the property when using dotaccess.
      */
-    Fetch (KeyOrPath, Cache = this.ValOptions.Cache) {
-        if (!this._Ready) return null;
-        if (typeof KeyOrPath !== "string") return null;
+    Fetch (keyOrPath, cache = this.valOptions.cache) {
+        if (!this._ready) return null;
+        if (typeof keyOrPath !== "string") return null;
 
-        const [Key, Path] = this._Resolve(KeyOrPath);
+        const [key, path] = this._Resolve(keyOrPath);
 
-        let Fetched = this.Cache.get(Key) || (() => {
-            const Req = this.API.prepare(`SELECT Val FROM '${this.Table}' WHERE Key = ?;`).get(Key);
-            if (typeof Req !== "undefined") return JSON.parse(Req.Val);
-            else return Req;
+        let fetched = this.memory.get(key) || (() => {
+            const document = this.API.prepare(`SELECT Val FROM '${this.table}' WHERE Key = ?;`).get(Key);
+            if (typeof document !== "undefined") return JSON.parse(document.Val);
+            return document;
         })();
 
-        if (Fetched === null || Fetched === undefined) return Fetched;
-        if (Cache && !this.Cache.has(Key)) this._Patch(Key, Fetched);
+        if (fetched === null || fetched === undefined) return fetched;
+        if (cache && !this.memory.has(key)) this._patch(key, fetched);
 
-        Fetched = Fetched instanceof Array ? [...Fetched] : {...Fetched};
-        if (typeof Path !== "undefined") Fetched = this._CastPath(Fetched, Path);
-        if (Fetched && typeof Fetched === "object") delete Fetched._Timestamp;
+        fetched = fetched instanceof Array ? [...fetched] : {...fetched};
+        if (typeof path !== "undefined") fetched = this._castPath(fetched, path);
+        if (fetched && typeof fetched === "object") delete fetched._timestamp;
 
-        return Fetched;
+        return fetched;
     }
 
     /**
      * Erases elements from this Connection's internal cache.
-     * @param {...Pathlike} [Keys] A key or multiple keys to remove from cache. If none, the cache will get cleared entirely.
+     * @param {...Pathlike} [keys] A key or multiple keys to remove from cache. If none, the cache will get cleared entirely.
      * @returns {Connection} Returns the current Connection.
      */
-    Evict (...Keys) {
-        if (!this._Ready) return null;
-        if (!(Keys instanceof Array)) return null;
+    evict (...keys) {
+        if (!this._ready) return null;
+        if (!(keys instanceof Array)) return null;
 
-        const Rows = Keys.filter(KeyOrPath => typeof KeyOrPath === "string")
-            .map(KeyOrPath => this._Resolve(KeyOrPath)[0]);
+        const rows = keys
+            .filter(keyOrPath => typeof keyOrPath === "string")
+            .map(keyOrPath => this._resolve(keyOrPath)[0]);
 
-        if (!Rows.length) this.Cache.clear();
-        else for (const Key of Rows) this.Cache.delete(Key);
+        if (!rows.length) this.memory.clear();
+        else for (const key of rows) this.memory.delete(key);
         return this;
     }
 
     /**
      * Manages the deletion of the database.
-     * @param {...Pathlike} Keys A key or multiple keys to remove from the database.
+     * @param {...Pathlike} keys A key or multiple keys to remove from the database.
      * These elements will also get removed from this Connection's internal cache.
      * @returns {Connection} Returns the current Connection.
      */
-    Erase (...Keys) {
-        if (!this._Ready) return null;
-        if (!(Keys instanceof Array)) return null;
+    erase (...keys) {
+        if (!this._ready) return null;
+        if (!(keys instanceof Array)) return null;
 
-        const Rows = Keys.filter(KeyOrPath => typeof KeyOrPath === "string")
-            .map(KeyOrPath => this._Resolve(KeyOrPath)[0]);
-            
-        if (Rows.length) {
-            this.Evict(...Rows);
-            this.API.prepare(`DELETE FROM '${this.Table}' WHERE Key IN (${Rows.map(_ => "?").join(", ")});`)
-            .run(...Rows);
+        const rows = keys
+            .filter(keyOrPath => typeof keyOrPath === "string")
+            .map(keyOrPath => this._resolve(keyOrPath)[0]);
+
+        if (rows.length) {
+            this.evict(...rows);
+            this.API
+                .prepare(`DELETE FROM '${this.table}' WHERE Key IN (${rows.map(_ => "?").join(", ")});`)
+                .run(...rows);
         }
 
         return this;
@@ -407,48 +427,54 @@ class Connection {
     /**
      * Returns whether or not a row in this database exists. This method also caches
      * the row internally, so fetching it afterwards would be much faster.
-     * @param {Pathlike} Key Specifies which row to see if it exists.
-     * @param {Boolean} [Cache] Whether or not to cache the fetched entry.
+     * @param {Pathlike} key Specifies which row to see if it exists.
+     * @param {Boolean} [cache] Whether or not to cache the fetched entry.
      * @returns {Boolean} Whether or not a row exists in this database.
      */
-    Exists (Key, Cache = this.ValOptions.UtilCache) {
-        if (!this._Ready) return false;
-        if (typeof Key !== "string") return false;
-        const Fetched = this.Fetch(Key, Cache);
-        return Fetched !== undefined;
+    exists (key, cache = this.valOptions.utilCache) {
+        if (!this._ready) return false;
+        if (typeof key !== "string") return false;
+
+        const fetched = this.fetch(key, cache);
+        return fetched !== undefined;
     }
 
     /**
      * Iterates through this database's entries.
-     * @param {Function} Fn A function which passes on the iterating entries.
+     * @param {Function} method A function which passes on the iterating entries.
      * @returns {Connection} Returns the current Connection.
      */
-    Each (Fn) {
-        if (!this._Ready) return null;
-        if (typeof Fn !== "function") return null;
+    each (method) {
+        if (!this._ready) return null;
+        if (typeof method !== "function") return null;
 
-        for (const Entry of this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).all())
-        Fn(JSON.parse(Entry.Val), Entry.Key);
+        const rows = this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).all();
+        for (const entry of rows) method(JSON.parse(entry.Val), entry.Key);
 
         return this;
     }
 
     /**
      * Iterates through all the entries of the database, returns the first element found.
-     * @param {Function} Fn A tester function which returns a boolean, based on the value(s) of the rows.
+     * @param {Function} predicate A tester function which returns a boolean, based on the value(s) of the rows.
      * @returns {Object|Array|DataModel} Returns the row which was found, or a nil value.
      */
-    Find (Fn) {
-        if (!this._Ready) return null;
-        if (typeof Fn !== "function") return null;
+    find (predicate) {
+        if (!this._ready) return null;
+        if (typeof predicate !== "function") return null;
 
-        if (this.ValOptions.Cache)
-        for (const [Key, Val] of this.Cache)
-        if (Fn(Val, Key)) return Val;
+        if (this.valOptions.cache) {
+            for (const [key, document] of this.memory)
+                if (predicate(document, key)) return document;
+        }
 
-        for (const Entry of this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).iterate()) {
-            const Column = JSON.parse(Entry.Val);
-            if (Fn(Column, Entry.Key)) return Column;
+        const iterableRows = this.API
+            .prepare(`SELECT Key, Val FROM '${this.table}';`)
+            .iterate();
+
+        for (const entry of iterableRows) {
+            const column = JSON.parse(entry.Val);
+            if (Fn(column, entry.Key)) return column;
         }
 
         return undefined;
@@ -457,26 +483,28 @@ class Connection {
     /**
      * Locally filters out rows in memory to work with.
      * Please note that this method does increase memory usage in large databases.
-     * @param {Function|Pathlike} FnOrPath A filter function or a path to a row.
+     * @param {Function|Pathlike} predicateOrPath A filter function or a path to a row.
      * @returns {Selection} A Selection class instance.
      */
-    Select (FnOrPath = () => true) {
-        if (!this._Ready) return null;
+    select (predicateOrPath = () => true) {
+        if (!this._ready) return null;
 
-        const Entries = typeof FnOrPath === "string" ? this.Fetch(FnOrPath) : (() => {
-            if (typeof FnOrPath !== "function") return {};
-            const Results = {};
+        const entries = typeof predicateOrPath === "string" ? this.fetch(predicateOrPath) : (() => {
+            if (typeof predicateOrPath !== "function") return {};
+            const rows = this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).all();
+            const results = {};
 
-            for (const Entry of this.API.prepare(`SELECT Key, Val FROM '${this.Table}';`).all()) {
-                const DecodedEntry = JSON.parse(Entry.Val);
-                if (FnOrPath(DecodedEntry, Entry.Key)) Results[Entry.Key] = DecodedEntry;
+            for (const entry of rows) {
+                const decodedEntry = JSON.parse(entry.Val);
+                if (predicateOrPath(decodedEntry, entry.Key))
+                    results[entry.Key] = decodedEntry;
             }
 
-            return Results;
+            return results;
         })();
 
         const Selection = require("../Utility/Selection");
-        return new Selection(Entries, this.Table);
+        return new Selection(entries, this.table);
     }
 
 
@@ -484,108 +512,111 @@ class Connection {
 
     /**
      * Pushes something to an array at the path output.
-     * @param {Pathlike} KeyOrPath Specifies which row or nested array to push to.
-     * @param {...Any} Values Values to insert and push to this array.
+     * @param {Pathlike} keyOrPath Specifies which row or nested array to push to.
+     * @param {...Any} values Values to insert and push to this array.
      * @returns {Number} New length of the array.
      */
-    Push (KeyOrPath, ...Values) {
-        if (!this._Ready)                  return null;
-        if (typeof KeyOrPath !== "string") return null;
-        if (!(Values instanceof Array))    return null;
-        
-        const Origin = this.Fetch(KeyOrPath);
-        if (!(Origin instanceof Array)) return null;
+    push (keyOrPath, ...values) {
+        if (!this._ready)                  return null;
+        if (typeof keyOrPath !== "string") return null;
+        if (!(values instanceof Array))    return null;
 
-        Origin.push(...Values);
-        this.Set(KeyOrPath, Origin);
-        return Origin.length;
+        const origin = this.fetch(keyOrPath);
+        if (!(origin instanceof Array)) return null;
+
+        origin.push(...values);
+        this.set(keyOrPath, origin);
+        return origin.length;
     }
 
     /**
      * Inserts (if defined) or removes a value to/from the front of the array.
-     * @param {Pathlike} KeyOrPath Specifies which row or nested array to insert to/remove from.
-     * @param {...Any} [Values] If defined, inserts new values at the front of the array.
+     * @param {Pathlike} keyOrPath Specifies which row or nested array to insert to/remove from.
+     * @param {...Any} [values] If defined, inserts new values at the front of the array.
      * @returns {Number|*} New length of the array if a value was inserted, or the shifted value.
      */
-    Shift (KeyOrPath, ...Values) {
-        if (!this._Ready)                  return null;
-        if (typeof KeyOrPath !== "string") return null;
-        if (!(Values instanceof Array))    return null;
+    shift (keyOrPath, ...values) {
+        if (!this._ready)                  return null;
+        if (typeof keyOrPath !== "string") return null;
+        if (!(values instanceof Array))    return null;
 
-        let Shifted  = undefined;
-        const Origin = this.Fetch(KeyOrPath);
-        if (!(Origin instanceof Array)) return null;
+        let shifted = undefined;
+        const origin = this.fetch(keyOrPath);
+        if (!(origin instanceof Array)) return null;
 
-        if (Values.length)
-        Origin.unshift(...Values);
-        else Shifted = Origin.shift();
+        values.length ?
+            origin.unshift(...values) :
+            shifted = origin.shift();
+            
+        this.set(keyOrPath, origin);
 
-        this.Set(KeyOrPath, Origin);
-        return !Values.length ? Shifted : Origin.length;
+        return !values.length ?
+            shifted :
+            origin.length;
     }
 
     /**
      * Pops something from an array at the path output.
-     * @param {Pathlike} KeyOrPath Specifies which row or nested array to pop from.
+     * @param {Pathlike} keyOrPath Specifies which row or nested array to pop from.
      * @returns {*} Returns the popped value.
      */
-    Pop (KeyOrPath) {
-        if (!this._Ready) return null;
-        if (typeof KeyOrPath !== "string") return null;
+    pop (keyOrPath) {
+        if (!this._ready) return null;
+        if (typeof keyOrPath !== "string") return null;
 
-        const Origin = this.Fetch(KeyOrPath);
-        if (!(Origin instanceof Array)) return null;
+        const origin = this.fetch(keyOrPath);
+        if (!(origin instanceof Array)) return null;
 
-        const Popped = Origin.pop();
-        this.Set(KeyOrPath, Origin);
-        return Popped;
+        const popped = origin.pop();
+        this.set(keyOrPath, origin);
+        return popped;
     }
 
     /**
      * Removes a specific element from this endpoint array.
-     * @param {Pathlike} KeyOrPath Specifies which row or nested array to remove a value from.
-     * @param {Function|Number} FnOrIdx Function or an index that specifies which item to remove.
+     * @param {Pathlike} keyOrPath Specifies which row or nested array to remove a value from.
+     * @param {Function|Number} predicateOrIdx Function or an index that specifies which item to remove.
      * @returns {Number} New length of the array.
      */
-    Remove (KeyOrPath, FnOrIdx) {
-        if (!this._Ready) return null;
-        if (typeof KeyOrPath !== "string") return null;
+    remove (keyOrPath, predicateOrIdx) {
+        if (!this._ready) return null;
+        if (typeof keyOrPath !== "string") return null;
 
-        const Origin = this.Fetch(KeyOrPath);
-        if (!(Origin instanceof Array)) return null;
+        const origin = this.fetch(keyOrPath);
+        if (!(origin instanceof Array)) return null;
 
-        if (typeof FnOrIdx === "function") {
-            for (const Key in Origin)
-            if (FnOrIdx(Origin[Key], Key)) {
-                Origin.splice(Key, 1);
+        if (typeof predicateOrIdx === "function") {
+            for (const key in origin)
+            if (predicateOrIdx(origin[key], key)) {
+                origin.splice(key, 1);
                 break;
             }
         } else {
-            if (typeof FnOrIdx !== "number") return Origin.length;
-            Origin.splice(FnOrIdx, 1);
+            if (typeof predicateOrIdx !== "number") return origin.length;
+            origin.splice(predicateOrIdx, 1);
         }
 
-        this.Set(KeyOrPath, Origin);
-        return Origin.length;
+        this.set(keyOrPath, origin);
+        return origin.length;
     }
 
     /**
      * Removes elements from this endpoint array based on indexes.
-     * @param {Pathlike} KeyOrPath Specifies which row or nested array to slice values from.
-     * @param {Number} [Start] Beginning of the specified portion of the array.
-     * @param {Number} [End] End of the specified portion of the array.
+     * @param {Pathlike} keyOrPath Specifies which row or nested array to slice values from.
+     * @param {Number} [startIdx] Beginning of the specified portion of the array.
+     * @param {Number} [endIdx] End of the specified portion of the array.
      * @returns {Number} New length of the array.
      */
-    Slice (KeyOrPath, Start, End) {
-        if (!this._Ready) return null;
-        if (typeof KeyOrPath !== "string") return null;
+    slice (keyOrPath, startIdx, endIdx) {
+        if (!this._ready) return null;
+        if (typeof keyOrPath !== "string") return null;
 
-        let Origin = this.Fetch(KeyOrPath);
-        if (!(Origin instanceof Array)) return null;
-        Origin = Origin.slice(Start, End);
+        let origin = this.fetch(keyOrPath);
+        if (!(origin instanceof Array)) return null;
+        origin = origin.slice(startIdx, endIdx);
 
-        this.Set(KeyOrPath, Origin);
-        return Origin.length;
+        this.set(keyOrPath, origin);
+        return origin.length;
     }
 
 
@@ -594,68 +625,67 @@ class Connection {
     /**
      * Inserts an input into a row or nested object if the key or path wasn't found at the endpoint.
      * It can be used as a default schema of the database elements, that gets inserted if there's no entry already.
-     * @param {Pathlike} KeyOrPath Context key to see if it exists, either a row or nested property, and optionally insert the new value.
-     * @param {Object|Array|Schema|*} Input A value to input if the row or nested property wasn't found in the database.
-     * @param {Boolean} [Merge] Whether or not to merge `Input` with this Connection's Schema model as initial values.
+     * @param {Pathlike} keyOrPath Context key to see if it exists, either a row or nested property, and optionally insert the new value.
+     * @param {Object|Array|Schema|*} input A value to input if the row or nested property wasn't found in the database.
+     * @param {Boolean} [merge] Whether or not to merge `Input` with this Connection's Schema model as initial values.
      * @returns {Boolean} Whether or not the new value was inserted.
      */
-    Ensure (KeyOrPath, Input = {}, Merge = !!this.ValOptions.Schema) {
-        if (!this._Ready)                  return null;
-        if (typeof KeyOrPath !== "string") return null;
-        if (typeof Input === "undefined")  return null;
+    ensure (keyOrPath, input = {}, merge = !!this.valOptions.schema) {
+        if (!this._ready)                  return null;
+        if (typeof keyOrPath !== "string") return null;
+        if (typeof input === "undefined")  return null;
 
-        const Exists = this.Exists(KeyOrPath);
-        if (KeyOrPath.includes(".")) Merge = false;
+        const exists = this.exists(keyOrPath);
+        merge = keyOrPath.includes(".") ? false : merge;
 
-        if (!Exists) {
-            const Value = Merge && typeof Input === "object" ?
-                this.ValOptions.Schema.Instance(Input) :
-                Input;
+        if (!exists) {
+            const value = merge && typeof input === "object" ?
+                this.valOptions.schema.instance(input) :
+                input;
 
-            this.Set(KeyOrPath, Value);
+            this.set(keyOrPath, value);
         }
-        
-        return !Exists;
+
+        return !exists;
     }
 
     /**
      * Updates a value if the entry exists by fetching it and passing it onto the callback function.
-     * @param {Pathlike} KeyOrPath Specifies which row or nested property to fetch.
-     * @param {Function} Fn Callback which includes the original value of the fetched row or property.
+     * @param {Pathlike} keyOrPath Specifies which row or nested property to fetch.
+     * @param {Function} method Callback which includes the original value of the fetched row or property.
      * @returns {Object|Array|DataModel} Returns the new row of the updated property.
      */
-    Modify (KeyOrPath, Fn) {
-        if (!this._Ready)                  return null;
-        if (typeof KeyOrPath !== "string") return null;
-        if (typeof Fn !== "function")      return null;
+    modify (keyOrPath, method) {
+        if (!this._ready)                  return null;
+        if (typeof keyOrPath !== "string") return null;
+        if (typeof method !== "function")  return null;
 
-        const Origin = this.Fetch(KeyOrPath);
-        const Key    = this._Resolve(KeyOrPath)[0];
+        const origin = this.fetch(keyOrPath);
+        const key    = this._resolve(keyOrPath)[0];
 
-        if (typeof Origin !== "undefined") {
-            const Value = Fn(Origin, Key);
-            this.Set(KeyOrPath, Value);
+        if (typeof origin !== "undefined") {
+            const value = method(origin, key);
+            this.set(keyOrPath, value);
         }
 
-        return Origin ?
-            this.Fetch(Key) :
+        return origin ?
+            this.fetch(key) :
             undefined;
     }
 
     /**
      * Inverts a boolean, from true to false and vice-versa, at the endpoint of the path.
-     * @param {Pathlike} KeyOrPath Specifies which row or nested property to boolean-invert.
+     * @param {Pathlike} keyOrPath Specifies which row or nested property to boolean-invert.
      * @returns {Boolean} Returns the updated boolean value of the property.
      */
-    Invert (KeyOrPath) {
-        if (!this._Ready) return null;
-        if (typeof KeyOrPath !== "string") return null;
+    invert (keyOrPath) {
+        if (!this._ready) return null;
+        if (typeof keyOrPath !== "string") return null;
 
-        const Insert = !this.Fetch(KeyOrPath);
-        this.Set(KeyOrPath, Insert);
-        return Insert;
+        const insert = !this.fetch(keyOrPath);
+        this.set(keyOrPath, insert);
+        return insert;
     }
-
 }
 
 module.exports = Connection;
@@ -666,25 +696,25 @@ module.exports = Connection;
  * All integer related options are in milliseconds.
  * @typedef {Object} RawOptions
 
- * @param {String} Table A name for the table to use at this path for this Connection.
- * @param {Schema} Schema Link to a database Schema class for automatic data migration.
+ * @param {String} table A name for the table to use at this path for this Connection.
+ * @param {Schema} schema Link to a database Schema class for automatic data migration.
  * @param {Boolean} WAL Whether or not to enable Write Ahead Logging mode.
 
- * @param {Function} Queries A function that gets ran for each executed SQL query in QDB.
+ * @param {Function} queries A function that gets ran for each executed SQL query in QDB.
 
- * @param {Boolean} Cache Whether to enable in-memory caching of entries in results that the next retrieval would be much faster.
- * @param {Boolean} FetchAll Whether or not to fetch all the database entries on start-up of this database Connection.
- * @param {Boolean} UtilCache Whether or not to cache entries while performing utility tasks, such as the Exists method.
+ * @param {Boolean} cache Whether to enable in-memory caching of entries in results that the next retrieval would be much faster.
+ * @param {Boolean} fetchAll Whether or not to fetch all the database entries on start-up of this database Connection.
+ * @param {Boolean} utilCache Whether or not to cache entries while performing utility tasks, such as the Exists method.
 
- * @param {Number} CacheMaxSize Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries.
- * @param {Number} SweepInterval Integer to indicate at what interval to sweep the entries of this Connection's internal cache.
- * @param {Number} SweepLifetime The minimum age of an entry in the cache to consider being sweepable after an interval.
+ * @param {Number} cacheMaxSize Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries.
+ * @param {Number} sweepInterval Integer to indicate at what interval to sweep the entries of this Connection's internal cache.
+ * @param {Number} sweepLifetime The minimum age of an entry in the cache to consider being sweepable after an interval.
  */
 
 /**
  * An entry which has been resolved from the Connection's internal cache.
  * @typedef {Object|Array} DataModel
- * @param {Number} _Timestamp Timestamp when this entry was last patched.
+ * @param {Number} _timestamp Timestamp when this entry was last patched.
  */
 
 /**

--- a/lib/Connections/Executors/Fetch.js
+++ b/lib/Connections/Executors/Fetch.js
@@ -1,17 +1,16 @@
 
 /**
  * Fetches everything in this Connection and caches it internally.
- * @param {Connection} Connection Reference to this Executor's Connection.
+ * @param {Connection} connection Reference to this Executor's Connection.
  * @returns {Number} Size of the cache.
  */
-module.exports = Connection => {
+module.exports = connection => {
+    const maxSize = connection.valOptions.cacheMaxSize;
+    if (maxSize !== false && maxSize <= 0) return null;
+    if (maxSize && typeof maxSize !== "number") return null;
 
-    const MaxSize = Connection.ValOptions.CacheMaxSize;
-    if (MaxSize !== false && MaxSize <= 0)      return null;
-    if (MaxSize && typeof MaxSize !== "number") return null;
-
-    Connection.API.prepare(`SELECT Key, Val FROM '${Connection.Table}'${MaxSize ? ` LIMIT 0,${MaxSize}` : ""};`)
-    .all().forEach(Entry => Connection._Patch(Entry.Key, JSON.parse(Entry.Val)));
-    return Connection.CacheSize;
-
+    connection.API.prepare(`SELECT Key, Val FROM '${connection.table}'${maxSize ? ` LIMIT 0,${maxSize}` : ""};`)
+        .all()
+        .forEach(entry => connection._patch(entry.Key, JSON.parse(entry.Val)));
+    return connection.cacheSize;
 }

--- a/lib/Connections/Executors/Index.js
+++ b/lib/Connections/Executors/Index.js
@@ -2,9 +2,9 @@
 "use strict";
 
 const Executors = {
-    Schema:        require("./Schema"),
-    FetchAll:      require("./Fetch"),
-    SweepInterval: require("./Sweep")
+    schema:        require("./Schema"),
+    fetchAll:      require("./Fetch"),
+    sweepInterval: require("./Sweep")
 };
 
 module.exports = Executors;

--- a/lib/Connections/Executors/Schema.js
+++ b/lib/Connections/Executors/Schema.js
@@ -4,20 +4,19 @@ const {Schema} = require("../../Utility/Schema");
 /**
  * Automatically migrate the database's entries upon a change in the Schema Model.
  * Use the `--migrate` or `-m` command line argument to migrate the database entries on startup of this Connection.
- * @param {Connection} Connection Reference to this Executor's Connection.
+ * @param {Connection} connection Reference to this Executor's Connection.
  * @returns {Boolean} Whether or not, when this Connection was instantiated, a data migration happened.
  */
-module.exports = Connection => {
+module.exports = connection => {
+    const shouldMigrateEntries = ["--migrate", "-m"].some(argument => process.argv.includes(argument));
+    const model = connection.valOptions.schema;
+    if (!(model instanceof Schema)) return null;
 
-    const Model = Connection.ValOptions.Schema;
-    if (!(Model instanceof Schema)) return null;
-
-    if (["--migrate", "-m"].some(Arg => process.argv.includes(Arg))) {
-        const Transaction = Connection.Transaction();
-        Connection.Each((Entry, Key) => Connection.Set(Key, Model.Instance(Entry)));
-        return Transaction.Commit();
+    if (shouldMigrateEntries) {
+        const transaction = connection.transaction();
+        connection.each((entry, key) => connection.set(key, model.instance(entry)));
+        return transaction.commit();
     }
-    
-    return false;
 
+    return false;
 }

--- a/lib/Connections/Executors/Schema.js
+++ b/lib/Connections/Executors/Schema.js
@@ -1,5 +1,5 @@
 
-const {Schema} = require("../../Utility/Schema");
+const { Schema } = require("../../Utility/Schema");
 
 /**
  * Automatically migrate the database's entries upon a change in the Schema Model.

--- a/lib/Connections/Executors/Sweep.js
+++ b/lib/Connections/Executors/Sweep.js
@@ -2,24 +2,22 @@
 /**
  * Sweep manager of the Connection, according to given options.
  * Disabled when the Connection's cache option is false.
- * @param {Connection} Connection Reference to this Executor's Connection.
+ * @param {Connection} connection Reference to this Executor's Connection.
  * @returns {Function?} Interval identifier to clear on disconnect.
  */
-module.exports = Connection => {
-
-    if (!Connection.ValOptions.Cache) return null;
+module.exports = connection => {
+    if (!connection.valOptions.cache) return null;
 
     const {
-        SweepLifetime: Lifetime,
-        SweepInterval: Interval
-    } = Connection.ValOptions;
+        sweepLifetime: lifetime,
+        sweepInterval: interval
+    } = connection.valOptions;
 
     return setInterval(() => {
-        const Time = Date.now();
-        Connection.Cache.each((Entry, Key) => {
-            if (Time - Entry._Timestamp >= Lifetime)
-            Connection.Cache.delete(Key);
+        const time = Date.now();
+        connection.memory.each((entry, key) => {
+            if (time - entry._timestamp >= lifetime)
+                connection.memory.delete(key);
         });
-    }, Interval);
-
+    }, interval);
 }

--- a/lib/Connections/Pool.js
+++ b/lib/Connections/Pool.js
@@ -8,84 +8,84 @@ class Pool {
 
     /**
      * A utility class for managing multiple database Connections.
-     * @param {Pathlike} PathURL Path to the database file or directory for this Pool to operate.
-     * @param {PoolOptions} [PoolOptions] Options for this Pool to manage, including separate Connection options.
-     * @example const MyDBs = new QDB.Pool("lib/Databases/");
+     * @param {Pathlike} pathURL Path to the database file or directory for this Pool to operate.
+     * @param {PoolOptions} [poolOptions] Options for this Pool to manage, including separate Connection options.
+     * @example const myDBs = new QDB.Pool("/usr/Production/Cellar/");
      */
-    constructor (PathURL, PoolOptions = {}) {
+    constructor (pathURL, poolOptions = {}) {
 
         /**
          * Path string to the Pool directory.
-         * @name Pool#Path
+         * @name Pool#path
          * @type {Pathlike}
          * @readonly
          */
-        Object.defineProperty(this, "Path", {
+        Object.defineProperty(this, "path", {
             enumerable: true,
-            value: PathURL
+            value: pathURL
         });
 
         /**
          * A collection of databases this Pool holds.
-         * @name Pool#Store
+         * @name Pool#store
          * @type {Collection}
          * @link https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md
          * @readonly
          */
-        Object.defineProperty(this, "Store", {
+        Object.defineProperty(this, "store", {
             enumerable: true,
             value: new Qulity.Collection()
         });
 
         /**
          * Options for this Pool.
-         * @name Pool#ValOptions
+         * @name Pool#valOptions
          * @type {PoolOptions}
          * @readonly
          */
-        Object.defineProperty(this, "ValOptions", {
+        Object.defineProperty(this, "valOptions", {
             value: {
-                Exclusives: {},
-                Binding: true,
+                exclusives: {},
+                binding: true,
 
                 WAL:       true,
-                Cache:     true,
-                UtilCache: true,
+                cache:     true,
+                utilCache: true,
 
-                CacheMaxSize:  false,
-                SweepInterval: 300000,
-                SweepLifetime: 150000,
+                cacheMaxSize:  false,
+                sweepInterval: 300000,
+                sweepLifetime: 150000,
 
-                ...PoolOptions
+                ...poolOptions
             }
         });
 
-        const Iterator = require("./Pool/Iterator");
-        if (FS.existsSync(PathURL)) Iterator(this);
-
+        const iterator = require("./Pool/Iterator");
+        if (FS.existsSync(PathURL)) iterator(this);
     }
 
 
     /**
      * Retrieves a database Connection from this Pool instance.
-     * @param {String} Base Reference link to the Connection to resolve.
+     * @param {String} base Reference link to the Connection to resolve.
      * @returns {Connection}
      */
-    Select (Base) {
-        if (typeof Base !== "string") return null;
-        return this.Store.get(Base);
+    select (base) {
+        return typeof base === "string" ?
+            this.store.get(base) :
+            null;
     }
 
     /**
      * Disconnects from all the Connections in this Pool.
      * @returns {Pool}
      */
-    Disconnect () {
-        this.Store.each(Connection => Connection.Disconnect());
-        this.Store.clear();
+    disconnect () {
+        this.store
+            .each(connection => connection.disconnect())
+            .clear();
         return this;
     }
-
 }
 
 module.exports = Pool;
@@ -96,14 +96,14 @@ module.exports = Pool;
  * All integer related options are in milliseconds.
  * @typedef {Object} PoolOptions
 
- * @param {Object<Identifier, RawOptions>} Exclusives Non-default options to use for certain Connections to a database.
- * @param {Boolean} Binding Whether or not to automatically bind Schemas with the table names in the Pool.
+ * @param {Object<Identifier, RawOptions>} exclusives Non-default options to use for certain Connections to a database.
+ * @param {Boolean} binding Whether or not to automatically bind Schemas with the table names in the Pool.
 
  * @param {Boolean} WAL Default setting to enable Write Ahead Logging mode for Connections in this Pool.
- * @param {Boolean} Cache Whether to enable in-memory caching of entries in results that the next retrieval would be much faster.
- * @param {Boolean} UtilCache Whether or not to cache entries while performing utility tasks, such as the Exists method.
+ * @param {Boolean} cache Whether to enable in-memory caching of entries in results that the next retrieval would be much faster.
+ * @param {Boolean} utilCache Whether or not to cache entries while performing utility tasks, such as the Exists method.
 
- * @param {Number} CacheMaxSize Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries.
- * @param {Number} SweepInterval Integer to indicate at what interval to sweep the entries of the Connection's internal cache.
- * @param {Number} SweepLifetime The minimum age of an entry in the cache to consider being sweepable after an interval.
+ * @param {Number} cacheMaxSize Amount to be considered the maximum size. If this threshold is hit, the cache will temporarily stop adding new entries.
+ * @param {Number} sweepInterval Integer to indicate at what interval to sweep the entries of the Connection's internal cache.
+ * @param {Number} sweepLifetime The minimum age of an entry in the cache to consider being sweepable after an interval.
  */

--- a/lib/Connections/Pool.js
+++ b/lib/Connections/Pool.js
@@ -13,7 +13,6 @@ class Pool {
      * @example const myDBs = new QDB.Pool("/usr/Production/Cellar/");
      */
     constructor (pathURL, poolOptions = {}) {
-
         /**
          * Path string to the Pool directory.
          * @name Pool#path
@@ -61,7 +60,7 @@ class Pool {
         });
 
         const iterator = require("./Pool/Iterator");
-        if (FS.existsSync(PathURL)) iterator(this);
+        if (FS.existsSync(pathURL)) iterator(this);
     }
 
 

--- a/lib/Connections/Pool/Iterator.js
+++ b/lib/Connections/Pool/Iterator.js
@@ -4,7 +4,6 @@ const tables   = require("./Tables");
 
 const { lstatSync, readdirSync } = require("fs");
 
-
 module.exports = pool => {
     const { path: pathURL } = pool;
 

--- a/lib/Connections/Pool/Iterator.js
+++ b/lib/Connections/Pool/Iterator.js
@@ -1,22 +1,22 @@
 
-const Tables = require("./Tables");
+const { join } = require("path");
+const tables   = require("./Tables");
 
-const FS   = require("fs");
-const Path = require("path");
+const { lstatSync, readdirSync } = require("fs");
 
-module.exports = Pool => {
 
-    const {Path: PathURL} = Pool;
-    const BaseOptions = {
-        ...Pool.ValOptions,
-        Exclusives: null
+module.exports = pool => {
+    const { path: pathURL } = pool;
+
+    const baseOptions = {
+        ...pool.valOptions,
+        exclusives: undefined
     };
 
-    if (FS.lstatSync(PathURL).isDirectory()) return FS.readdirSync(PathURL)
-    .filter(Name => ["sqlite", "qdb", "db"].includes(Name.split(".").pop()))
-    .filter(Name => !["-wal", "-shm"].some(Arg => Name.endsWith(Arg)))
-    .forEach(Database => Tables(Pool, Path.join(PathURL, Database), BaseOptions));
+    if (lstatSync(pathURL).isDirectory()) return readdirSync(pathURL)
+        .filter(name => ["sqlite", "qdb", "db"].includes(name.split(".").pop()))
+        .filter(name => !["-wal", "-shm"].some(argument => name.endsWith(argument)))
+        .forEach(database => tables(pool, join(pathURL, database), baseOptions));
 
-    return Tables(Pool, PathURL, BaseOptions);
-
+    return tables(pool, pathURL, baseOptions);
 }

--- a/lib/Connections/Pool/Tables.js
+++ b/lib/Connections/Pool/Tables.js
@@ -1,31 +1,38 @@
 
 const Connection = require("../Connection");
-const {Model}    = require("../../../QDB");
+const SQL        = require("better-sqlite3");
 
-const Path = require("path");
-const SQL  = require("better-sqlite3");
+const { basename } = require("path");
+const { model }    = require("../../../QDB");
 
-module.exports = (Pool, PathURL, BaseOptions) => {
+module.exports = (pool, pathURL, baseOptions) => {
     try {
-        const Main = new SQL(PathURL);
+        const main = new SQL(pathURL);
 
-        Main.prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table';")
-        .all().map(Entry => Entry.name).forEach((Table, _i, All) => {
-            const Identifier = All.length > 1 ? Table :
-            Path.basename(PathURL).split(".")[0];
+        main
+            .prepare("SELECT name FROM 'sqlite_master' WHERE type = 'table';")
+            .all()
+            .map(entry => entry.name)
+            .forEach((table, _i, all) => {
+                const identifier = all.length > 1 ?
+                    table :
+                    basename(pathURL).split(".")[0];
 
-            const Schema = BaseOptions.Binding ? Model(Table) : undefined;
+                const schema = baseOptions.binding ?
+                    model(Table) :
+                    undefined;
 
-            Pool.Store.set(Identifier,
-                new Connection(PathURL, {
-                    Schema,
-                    ...BaseOptions,
-                    ...Pool.ValOptions.Exclusives[Identifier],
-                    Identifier, Table
-                }, Pool)
-            );
-        });
+                pool.store.set(identifier,
+                    new Connection(pathURL, {
+                        schema,
+                        ...baseOptions,
+                        ...pool.valOptions.exclusives[identifier],
+                        identifier,
+                        table
+                    }, pool)
+                );
+            });
 
-        Main.close();
+        main.close();
     } catch (_) {}
 }

--- a/lib/Connections/Pool/Tables.js
+++ b/lib/Connections/Pool/Tables.js
@@ -19,7 +19,7 @@ module.exports = (pool, pathURL, baseOptions) => {
                     basename(pathURL).split(".")[0];
 
                 const schema = baseOptions.binding ?
-                    model(Table) :
+                    model(table) :
                     undefined;
 
                 pool.store.set(identifier,

--- a/lib/Utility/Schema.js
+++ b/lib/Utility/Schema.js
@@ -1,70 +1,69 @@
 
 "use strict";
 
-const {DataStore} = require("qulity");
-const ModelStore  = new DataStore();
+const { DataStore } = require("qulity");
+
+const modelStore = new DataStore();
 
 class Schema {
 
     /**
      * A generic model that entries of a database automatically follows.
-     * @param {String} Id An identifier for this Schema Model.
-     * @param {Object|Array} Model An object or array, giving the layout and default values of entries.
-     * @param {Function} [Serialiser] A transformer object to implement, as a utility to fetch from some type of API or DataModel.
+     * @param {String} identifier An identifier for this Schema Model.
+     * @param {Object|Array} model An object or array, giving the layout and default values of entries.
+     * @param {Function} [serialiser] A transformer object to implement, as a utility to fetch from some type of API or DataModel.
      */
-    constructor (Id, Model, Serialiser = undefined) {
-
-        if (typeof Id !== "string")                         throw new Error("Schema identifier should be a type of String.");
-        if (typeof Model !== "object")                      throw new Error("Schema Models should be a type of Object or Array.");
-        if (Serialiser && typeof Serialiser !== "function") throw new Error("Schema Serialisers should be a Function which returns an Object or Array.");
+    constructor (identifier, model, serialiser = undefined) {
+        if (typeof identifier !== "string")                 throw new Error("Schema identifier should be a type of String.");
+        if (typeof model !== "object")                      throw new Error("Schema Models should be a type of Object or Array.");
+        if (serialiser && typeof serialiser !== "function") throw new Error("Schema Serialisers should be a Function which returns an Object or Array.");
 
         /**
          * The default model of this Schema.
-         * @name Schema#Model
+         * @name Schema#model
          * @type {Object|Array}
          * @readonly
          */
-        Object.defineProperty(this, "Model", {
+        Object.defineProperty(this, "model", {
             enumerable: true,
-            value: Model
+            value: model
         });
 
         /**
          * A Serialiser function that converts an
          * entry to a rich DataModel on request.
-         * @name Schema#_Serialiser
+         * @name Schema#_serialiser
          * @type {Function?}
          * @private
          */
-        Object.defineProperty(this, "_Serialiser", {
+        Object.defineProperty(this, "_serialiser", {
             enumerable: true,
-            value: Serialiser
+            value: serialiser
         });
 
-        ModelStore.set(Id, this);
-
+        modelStore.set(identifier, this);
     }
 
 
     /**
      * Serialises a supposed database entry to this Schema's rich DataModel,
      * if this Schema was instantiated with a Serialiser method.
-     * @name Schema#Serialise
+     * @name Schema#serialise
      * @type {Function}
      */
-    get Serialise () {
-        if (typeof this._Serialiser === "function")
-        return this._Serialiser;
-        else return Model => ({...Model});
+    get serialise () {
+        return typeof this._serialiser === "function" ?
+            this._serialiser :
+            model => ({ ...model });
     }
 
     /**
      * Public method.
      * Integrates an entry object and integrates them with this Schema's Model.
-     * @param {Object} Target The main entry to compare against and to merge changes into.
+     * @param {Object} target The main entry to compare against and to merge changes into.
      * @returns {Object} A merged data object based on this Schema's Model.
      */
-    Instance (Target = {}) {
+    Instance (target = {}) {
 
         // Depth Object Control
         // The object with the depth of 0 (root object) is always controlled fully (deleted and filled).
@@ -72,36 +71,37 @@ class Schema {
         // If it doesn't, then it will not delete nor fill the target object.
         // Arrays are never deleted or filled (regardless if it's filled in the schema, as it's a default).
 
-        (function Copy (Target, Schema) {
+        (function copy (target, schema) {
+            if (schema instanceof Array) {
+                return target instanceof Array ?
+                    [] :
+                    target = [];
+            } else if (target instanceof Array) {
+                target = {};
+            }
 
-            if (Schema instanceof Array) {
-                if (Target instanceof Array) return;
-                else return Target = [];
-            } else if (Target instanceof Array) Target = {};
+            if (Object.keys(schema).length === 0) return;
 
-            if (Object.keys(Schema).length === 0) return;
-
-            Object.keys(Target).forEach(Key => {
-                if (!Schema.hasOwnProperty(Key))
-                delete Target[Key];
+            Object.keys(target).forEach(key => {
+                if (!schema.hasOwnProperty(key))
+                delete target[key];
             });
 
-            Object.keys(Schema).forEach(Key => {
-                const SchemaVal = Schema[Key];
-                const TargetVal = Target[Key];
+            Object.keys(schema).forEach(key => {
+                const schemaVal = schema[key];
+                const targetVal = target[key];
 
-                if (!Target.hasOwnProperty(Key)) Target[Key] = SchemaVal;
-                else if (SchemaVal && typeof SchemaVal === "object") Copy(TargetVal, SchemaVal);
+                if (!target.hasOwnProperty(key)) target[key] = schemaVal;
+                else if (schemaVal && typeof schemaVal === "object") copy(targetVal, schemaVal);
             });
+        })(target, this.model);
 
-        })(Target, this.Model);
-
-        return Target;
+        return target;
     }
     
 }
 
 module.exports = {
     Schema,
-    ModelStore
+    modelStore
 };

--- a/lib/Utility/Selection.js
+++ b/lib/Utility/Selection.js
@@ -1,88 +1,86 @@
 
 "use strict";
 
-const {Collection} = require("qulity");
+const { Collection } = require("qulity");
 
 class Selection {
 
     /**
      * An unchanged piece of the database in memory, to use
      * as baseline of various endpoints to execute functions with.
-     * @param {Object} _Entries Initial selection of entries for this Selection instance.
-     * @param {String} _Holds Reference to the table this Selection will hold.
+     * @param {Object} _entries Initial selection of entries for this Selection instance.
+     * @param {String} _holds Reference to the table this Selection will hold.
      * @example const Selection = MyDB.Select(User => User.Age > 20);
      */
-    constructor (_Entries, _Holds) {
-        
+    constructor (_entries, _holds) {
         /**
          * Cached dataset of this Selection.
-         * @name Selection#Cache
+         * @name Selection#cache
          * @type {Collection}
          * @link https://github.com/QSmally/Qulity/blob/master/Documentation/Collection.md
          * @readonly
          */
-        Object.defineProperty(this, "Cache", {
+        Object.defineProperty(this, "cache", {
             enumerable: true,
             value: new Collection()
         });
 
-        for (const Id in _Entries)
-        this.Cache.set(Id, _Entries[Id]);
+        for (const id in _entries)
+            this.cache.set(id, _entries[id]);
 
         /**
          * Reference to the table this Selection holds.
-         * @name Selection#Holds
+         * @name Selection#holds
          * @type {String}
          * @readonly
          */
-        Object.defineProperty(this, "Holds", {
+        Object.defineProperty(this, "holds", {
             enumerable: true,
-            value: _Holds
+            value: _holds
         });
-
     }
 
 
     /**
      * Serialises this Selection's keys into an array.
-     * @name Selection#Keys
+     * @name Selection#keys
      * @type {Array}
      */
-    get Keys () {
-        return this.Cache.toKeyArray();
+    get keys () {
+        return this.cache.toKeyArray();
     }
 
     /**
      * Serialises this Selection's values into an array.
-     * @name Selection#Values
+     * @name Selection#values
      * @type {Array}
      */
-    get Values () {
-        return this.Cache.toArray();
+    get values () {
+        return this.cache.toArray();
     }
 
     /**
      * Serialises this Selection into an object.
-     * @name Selection#AsObject
+     * @name Selection#asObject
      * @type {Object}
      */
-    get AsObject () {
-        return this.Cache.toPairObject();
+    get asObject () {
+        return this.cache.toPairObject();
     }
 
 
     /**
      * Returns the given document by its key from this Selection.
-     * @param {Pathlike} KeyOrPath Indicates which (nested) element to receieve.
+     * @param {Pathlike} keyOrPath Indicates which (nested) element to receieve.
      * @returns {Object|Array|DataModel}
      */
-    Retrieve (KeyOrPath) {
-        if (typeof KeyOrPath !== "string") return null;
-        const [Key, ...Path] = KeyOrPath.split(".");
-        const Document = this.Cache.get(Key);
+    retrieve (keyOrPath) {
+        if (typeof keyOrPath !== "string") return null;
+        const [key, ...path] = keyOrPath.split(".");
+        const documentObject = this.cache.get(key);
 
-        if (!Path.length) return Document;
-        return this._CastPath(Document, Path);
+        if (!path.length) return documentObject;
+        return this._castPath(documentObject, path);
     }
 
 
@@ -91,22 +89,22 @@ class Selection {
     /**
      * Internal method.
      * Finds a relative dotaccess pathway of an object.
-     * @param {Object|Array} Frame The object-like beginning to cast.
-     * @param {Array} Pathlike A dotaccess notation path, as an Array split by dots.
+     * @param {Object|Array} frame The object-like beginning to cast.
+     * @param {Array} pathlike A dotaccess notation path, as an Array split by dots.
      * @returns {*} Returns the output of the caster.
      * @private
      */
-    _CastPath (Frame, Pathlike) {
-        const KeyLast = Pathlike.pop();
+    _castPath (frame, pathlike) {
+        const lastFrameKey = pathlike.pop();
 
-        for (const Key of Pathlike) {
-            if (typeof Frame !== "object") return;
-            if (!(Key in Frame)) return;
-            Frame = Frame[Key];
+        for (const key of pathlike) {
+            if (typeof frame !== "object") return;
+            if (!(key in frame)) return;
+            frame = frame[key];
         }
 
-        return Frame ?
-            Frame[KeyLast] :
+        return frame ?
+            frame[lastFrameKey] :
             undefined;
     }
 
@@ -116,42 +114,28 @@ class Selection {
     /**
      * Sorts this Selection's values.
      * Identical to the `ORDER BY` SQL statement.
-     * @param {Function} Fn Function that determines the sort order with given arguments `a` and `b`.
+     * @param {Function} predicate Function that determines the sort order with given arguments `a` and `b`.
      * @returns {Selection}
      */
-    Order (Fn) {
-        if (typeof Fn === "function")
-        this.Cache.sort(Fn, this);
-        return this;
-    }
-
-    /**
-     * Sorts this Selection's values.
-     * Identical to the `ORDER BY ... [DESC]` SQL statement.
-     * @param {Function} Fn Function that determines which number to order by.
-     * @returns {Selection}
-     */
-    OrderBy (Fn, Order = "DESC") {
-        if (typeof Fn === "function") {
-            const Asc = (a, b) => Fn(a) - Fn(b);
-            const Desc = (a, b) => Fn(b) - Fn(a);
-            this.Cache.sort(Order === "ASC" ? Asc : Desc, this);
-        }
-
+    order (predicate) {
+        if (typeof predicate === "function")
+            this.cache.sort(predicate, this);
         return this;
     }
 
     /**
      * Filters values that satisfy the provided function.
      * Identical to the `FILTER BY` SQL statement.
-     * @param {Function} Fn Function that determines which entries to keep.
+     * @param {Function} predicate Function that determines which entries to keep.
      * @returns {Selection}
      */
-    Filter (Fn) {
-        if (typeof Fn === "function") {
-            Fn = Fn.bind(this);
-            for (const [Key, Val] of this.Cache)
-            if (!Fn(Val, Key, this)) this.Cache.delete(Key);
+    filter (predicate) {
+        if (typeof predicate === "function") {
+            predicate = predicate.bind(this);
+            for (const [key, documentObject] of this.cache) {
+                if (!predicate(documentObject, key, this))
+                    this.cache.delete(key);
+            }
         }
 
         return this;
@@ -160,20 +144,20 @@ class Selection {
     /**
      * Slices off values from this Selection.
      * Identical to the `LIMIT` SQL statement.
-     * @param {Number} Begin Index that indicates the beginning to slice.
-     * @param {Number} [End] An index for the end of the slice.
+     * @param {Number} begin Index that indicates the beginning to slice.
+     * @param {Number} [end] An index for the end of the slice.
      * @returns {Selection}
      */
-    Limit (Begin, End = undefined) {
-        if (typeof Begin !== "number")      return this;
-        if (End && typeof End !== "number") return this;
-        if (!End) End = this.Cache.size;
+    limit (begin, end = undefined) {
+        if (typeof begin !== "number")      return this;
+        if (end && typeof end !== "number") return this;
+        if (!end) end = this.cache.size;
 
         let i = 0;
 
-        for (const Key of this.Cache) {
-            if (i < Begin || i >= End)
-            this.Cache.delete(Key[0]);
+        for (const key of this.cache) {
+            if (i < begin || i >= end)
+                this.cache.delete(key[0]);
             i++;
         }
 
@@ -183,24 +167,24 @@ class Selection {
     /**
      * Groups this Selection based on an identifier.
      * Identical to the `GROUP BY` SQL statement.
-     * @param {Pathlike} KeyOrPath Determines by which property to group this Selection.
+     * @param {Pathlike} keyOrPath Determines by which property to group this Selection.
      * @returns {Selection}
      */
-    Group (KeyOrPath) {
-        if (typeof KeyOrPath !== "string") return null;
-        const Original = this.Cache.toPairObject();
-        this.Cache.clear();
+    group (keyOrPath) {
+        if (typeof keyOrPath !== "string") return null;
+        const originalSelection = this.cache.toPairObject();
+        this.cache.clear();
 
-        for (const Idx in Original) {
-            const Row = Original[Idx];
-            const Field = this._CastPath(Row, KeyOrPath.split(/\.+/g));
-            const Group = this.Cache.get(Field);
+        for (const idx in originalSelection) {
+            const row = originalSelection[idx];
+            const field = this._castPath(row, keyOrPath.split(/\.+/g));
+            const group = this.cache.get(field);
 
-            if (Group) {
-                Group[Idx] = Row;
-                this.Cache.set(Field, Group);
+            if (group) {
+                group[idx] = row;
+                this.cache.set(field, group);
             } else {
-                this.Cache.set(Field, {[Idx]: Row});
+                this.cache.set(field, { [idx]: row });
             }
         }
 
@@ -210,28 +194,29 @@ class Selection {
     /**
      * Joins another Selection into this instance based on a referrer field.
      * Identical to the `FULL JOIN` SQL statement.
-     * @param {Selection} Secondary Another Selection instance to join into this one.
-     * @param {String} Field Which field to check for a reference to this Selection's rows, or `null` to join with keys.
-     * @param {Boolean|String} [Property] Boolean false to flatten the entries into this Selection's rows,
+     * @param {Selection} secondary Another Selection instance to join into this one.
+     * @param {String} field Which field to check for a reference to this Selection's rows, or `null` to join with keys.
+     * @param {Boolean|String} [property] Boolean false to flatten the entries into this Selection's rows,
      * a string value that implicitly indicates the property to add the merging entries,
      * or a boolean true to use the Selection's table name as property.
      * @returns {Selection}
      */
-    Join (Secondary, Field, Property = true) {
-        if (!(Secondary instanceof Selection)) return null;
-        if (typeof Field !== "string" && Field !== null) return null;
+    join (secondary, field, property = true) {
+        if (!(secondary instanceof Selection)) return null;
+        if (typeof field !== "string" && field !== null) return null;
 
-        const Key = typeof Property === "string" ? Property : Secondary.Holds;
-        if (Property) this.Map(Entry => { Entry[Key] = {}; return Entry; });
+        const key = typeof property === "string" ? property : secondary.holds;
+        if (property) this.map(entry => { entry[key] = {}; return entry; });
 
-        for (const [Id, Val] of Secondary.Cache) {
-            const FieldId = Field ? this._CastPath(Val, Field.split(/\.+/g)) : Id;
-            const Origin = this.Cache.get(FieldId);
-            if (!Origin) continue;
+        for (const [id, documentObject] of secondary.cache) {
+            const fieldId = field ? this._castPath(documentObject, field.split(/\.+/g)) : id;
+            const origin = this.cache.get(fieldId);
+            if (!origin) continue;
 
-            if (!Property) Origin[Id] = Val;
-            else Origin[Key][Id] = Val;
-            this.Cache.set(FieldId, Origin);
+            !property ?
+                origin[id] = documentObject :
+                origin[key][id] = documentObject;
+            this.cache.set(fieldId, origin);
         }
 
         return this;
@@ -242,45 +227,44 @@ class Selection {
 
     /**
      * Iterates over this Selection's values and keys, and implements the new values returned from the callback.
-     * @param {Function} Fn Callback function which determines the new values of the Selection.
+     * @param {Function} fn Callback function which determines the new values of the Selection.
      * @returns {Selection}
      */
-    Map (Fn) {
-        if (typeof Fn !== "function") return null;
+    map (fn) {
+        if (typeof fn !== "function") return null;
         let i = 0;
 
-        for (const [Key, Val] of this.Cache)
-        this.Cache.set(Key, Fn(Val, Key, i++));
+        for (const [key, documentObject] of this.cache)
+            this.cache.set(key, fn(documentObject, key, i++));
 
         return this;
     }
 
     /**
      * Automatically clones the merging Selections and adds them into this instance.
-     * @param {...Selection} Selections Instances to clone and merge into this one.
+     * @param {...Selection} selections Instances to clone and merge into this one.
      * @returns {Selection}
      */
-    Merge (...Selections) {
-        if (!(Selections instanceof Array)) return null;
+    merge (...selections) {
+        if (!(selections instanceof Array)) return null;
 
-        for (const Sel of Selections.map(Sel => Sel.Clone()))
-        for (const [Key, Val] of Sel.Cache)
-        this.Cache.set(Key, Val);
+        for (const sel of selections.map(sel => sel.clone()))
+            for (const [key, documentObject] of sel.cache)
+                this.cache.set(key, documentObject);
 
         return this;
     }
 
     /**
      * Creates a new memory allocation for the copy of this Selection.
-     * @param {String} [Holds] Optional new identifier value for the cloned Selection.
+     * @param {String} [holds] Optional new identifier value for the cloned Selection.
      * @returns {Selection}
      */
-    Clone (Holds = undefined) {
-        const {serialize, deserialize} = require("v8");
-        const SelectionPairs = deserialize(serialize(this.AsObject));
-        return new Selection(SelectionPairs, Holds || this.Holds);
+    clone (holds = undefined) {
+        const { serialize, deserialize } = require("v8");
+        const selectionPairs = deserialize(serialize(this.asObject));
+        return new Selection(selectionPairs, holds || this.holds);
     }
-
 }
 
 module.exports = Selection;

--- a/lib/Utility/Transaction.js
+++ b/lib/Utility/Transaction.js
@@ -5,35 +5,33 @@ class Transaction {
 
     /**
      * A SQL transaction manager.
-     * @param {Connection} _Connection A Connection this Transaction is referring to.
-     * @example const Transaction = MyDB.Transaction();
+     * @param {Connection} _connection A Connection this Transaction is referring to.
+     * @example const transaction = myDB.transaction();
      */
-    constructor (_Connection) {
-
+    constructor (_connection) {
         /**
          * Transaction's Connection reference.
-         * @name Transaction#_Connection
+         * @name Transaction#_connection
          * @type {Connection}
          * @private
          */
-        Object.defineProperty(this, "_Connection", {
-            value: _Connection
+        Object.defineProperty(this, "_connection", {
+            value: _connection
         });
 
         /**
          * Whether this Transaction is active.
-         * @name Transaction#Active
+         * @name Transaction#active
          * @type {Boolean}
          * @readonly
          */
-        Object.defineProperty(this, "Active", {
+        Object.defineProperty(this, "active", {
             enumerable: true,
             writable:   true,
             value:      true
         });
 
-        this._Connection.API.prepare("BEGIN;").run();
-
+        this._connection.API.prepare("BEGIN;").run();
     }
 
 
@@ -41,13 +39,13 @@ class Transaction {
      * Publishes the changes made during this Transaction.
      * @returns {Boolean} Whether the changed were committed.
      */
-    Commit () {
-        if (!this.Active)                        return false;
-        if (!this._Connection.API.inTransaction) return false;
-        if (!this._Connection._Ready)            return false;
+    commit () {
+        if (!this.active)                        return false;
+        if (!this._connection.API.inTransaction) return false;
+        if (!this._connection._ready)            return false;
 
-        this._Connection.API.prepare("COMMIT;").run();
-        this.Active = false;
+        this._connection.API.prepare("COMMIT;").run();
+        this.active = false;
         return true;
     }
 
@@ -56,17 +54,16 @@ class Transaction {
      * This also clears the contents of the Connection's internal cache.
      * @returns {Boolean} Whether the changed were reset.
      */
-    Rollback () {
-        if (!this.Active)                        return false;
-        if (!this._Connection.API.inTransaction) return false;
-        if (!this._Connection._Ready)            return false;
+    rollback () {
+        if (!this.active)                        return false;
+        if (!this._connection.API.inTransaction) return false;
+        if (!this._connection._ready)            return false;
 
-        this._Connection.Cache.clear();
-        this._Connection.API.prepare("ROLLBACK;").run();
-        this.Active = false;
+        this._connection.memory.clear();
+        this._connection.API.prepare("ROLLBACK;").run();
+        this.active = false;
         return true;
     }
-
 }
 
 module.exports = Transaction;


### PR DESCRIPTION
As the majority of programmers use JavaScript's naming convention, I have decided that it would be better if QDB gets refactored to be primarily in camelCase as well. For classes, uninitialised, these will still be represented in PascalCase.

At the end of the story, I'll also refactor QDB a lot to maintain its functionality and performance.